### PR TITLE
Add middlemen

### DIFF
--- a/server/src/core/error.ts
+++ b/server/src/core/error.ts
@@ -64,7 +64,11 @@ export function createFundsToUserFailedError(message: string) {
 export function createAtApiError(message: string = messages.ERROR_AT_API_ERROR) {
   return createAppError(message, 'atApiError');
 }
-export function createBeneficiaryNominationFailedError (message: string = messages.ERROR_BENEFICIARY_NOMINATION_FAILED) {
+export function createBeneficiaryNominationFailedError(message: string = messages.ERROR_BENEFICIARY_NOMINATION_FAILED) {
+  return createAppError(message, 'nominationFailed');
+}
+
+export function createMiddlemanNominationFailedError(message: string = messages.ERROR_BENEFICIARY_NOMINATION_FAILED) {
   return createAppError(message, 'nominationFailed');
 }
 

--- a/server/src/core/error.ts
+++ b/server/src/core/error.ts
@@ -1,4 +1,5 @@
 import * as messages from './messages';
+import { MongoError } from 'mongodb';
 
 export class AppError extends Error {
   readonly code: ErrorCode;
@@ -9,6 +10,29 @@ export class AppError extends Error {
   }
 }
 
+// MongoDB error codes
+export const MONGO_ERROR_DUPLICATE_KEY = 11000;
+
+/**
+ * Checks whether the error is a MongoDB duplicate key error
+ * If a key is provided, then it also checks whether that was the key
+ * that triggered the duplicate error.
+ * @param error
+ * @param key
+ */
+export function isMongoDuplicateKeyError(error: MongoError, key?: any): boolean {
+  if (error.code !== MONGO_ERROR_DUPLICATE_KEY) {
+    return false;
+  }
+  
+  if (typeof key === 'undefined') {
+    return true;
+  }
+
+  return error.message.indexOf(key) > 0;
+}
+
+// Our error codes
 export type ErrorCode = 
   // database error occurred when performing db operation
   'dbOpFailed'
@@ -68,7 +92,7 @@ export function createBeneficiaryNominationFailedError(message: string = message
   return createAppError(message, 'nominationFailed');
 }
 
-export function createMiddlemanNominationFailedError(message: string = messages.ERROR_BENEFICIARY_NOMINATION_FAILED) {
+export function createMiddlemanNominationFailedError(message: string = messages.ERROR_MIDDLEMAN_NOMINATION_FAILED) {
   return createAppError(message, 'nominationFailed');
 }
 

--- a/server/src/core/messages.ts
+++ b/server/src/core/messages.ts
@@ -11,6 +11,7 @@ export const ERROR_ROUTE_NOT_FOUND = 'Route does not exist';
 export const ERROR_PHONE_ALREADY_IN_USE = 'The specified phone number is already in use';
 export const ERROR_AT_API_ERROR = 'AfricasTalking error occurred';
 export const ERROR_BENEFICIARY_NOMINATION_FAILED = 'Failed to nominate the specified user as a beneficiary';
+export const ERROR_USER_CANNOT_ADD_BENEFICIARY = 'User cannot nominator beneficiaries';
 export const ERROR_USER_CANNOT_BE_BENEFICIARY = 'The specified user cannot be nominated as beneficiary';
 export const ERROR_ADD_TO_BATCH_QUEUE_AFTER_EOF = 'Cannot add data to queue after eof has been signaled';
 export const ERROR_CONFLICTING_OPERATION_IN_PROGRESS = 'The operation failed because a conflicting operation is in progress. Please try again later.'

--- a/server/src/core/messages.ts
+++ b/server/src/core/messages.ts
@@ -12,6 +12,7 @@ export const ERROR_PHONE_ALREADY_IN_USE = 'The specified phone number is already
 export const ERROR_AT_API_ERROR = 'AfricasTalking error occurred';
 export const ERROR_BENEFICIARY_NOMINATION_FAILED = 'Failed to nominate the specified user as a beneficiary';
 export const ERROR_USER_CANNOT_ADD_BENEFICIARY = 'User cannot nominator beneficiaries';
+export const ERROR_MIDDLEMAN_NOMINATION_FAILED = 'Failed to nominate the specified user as a middleman';
 export const ERROR_USER_CANNOT_BE_BENEFICIARY = 'The specified user cannot be nominated as beneficiary';
 export const ERROR_ADD_TO_BATCH_QUEUE_AFTER_EOF = 'Cannot add data to queue after eof has been signaled';
 export const ERROR_CONFLICTING_OPERATION_IN_PROGRESS = 'The operation failed because a conflicting operation is in progress. Please try again later.'

--- a/server/src/core/system-lock/system-lock.ts
+++ b/server/src/core/system-lock/system-lock.ts
@@ -1,6 +1,6 @@
 import { Collection } from 'mongodb';
 import { SystemLock, SystemLockRecord } from './types';
-import { createSystemLockBusyError, AppError, createDbOpFailedError, createSystemLockInvalidStateError } from '../error';
+import { createSystemLockBusyError, AppError, createDbOpFailedError, createSystemLockInvalidStateError, isMongoDuplicateKeyError } from '../error';
 import * as messages from '../messages';
 
 
@@ -23,7 +23,7 @@ export class SystemLockManager implements SystemLock {
     }
     catch (e) {
       if (e instanceof AppError) throw e;
-      if (e.code == 11000 && e.message.indexOf(this.id) >= 0) throw createSystemLockBusyError();
+      if (isMongoDuplicateKeyError(e, this.id)) throw createSystemLockBusyError();
       throw createDbOpFailedError(e.message);
     }
   }

--- a/server/src/core/test-util.ts
+++ b/server/src/core/test-util.ts
@@ -158,6 +158,16 @@ export function createDateMocker (): DateMocker {
 }
 
 /**
+ * asserts that the specified dates are close to each other
+ * @param expected 
+ * @param actual 
+ * @param delta maximum allowed milliseconds between the dates
+ */
+export function expectDatesAreClose(expected: Date, actual: Date, delta: number = 1000) {
+  expect(Math.abs(expected.getTime() - actual.getTime()) < delta).toBe(true);
+}
+
+/**
  * creates a function which tests whether the specified validation function `fn`
  * returns true or false (`validState`) given certain inputs
  * @param fn the validation function
@@ -220,7 +230,7 @@ export function createDbUtils(dbName: string, defaultColl: string, dbHost: strin
      * `coll` is not specified
      * @param coll
      */
-    getCollection<T>(coll: string = defaultColl) {
+    getCollection<T = any>(coll: string = defaultColl) {
       return db.collection<T>(coll);
     },
 

--- a/server/src/core/test-util.ts
+++ b/server/src/core/test-util.ts
@@ -220,8 +220,8 @@ export function createDbUtils(dbName: string, defaultColl: string, dbHost: strin
      * `coll` is not specified
      * @param coll
      */
-    getCollection(coll: string = defaultColl) {
-      return db.collection(coll);
+    getCollection<T>(coll: string = defaultColl) {
+      return db.collection<T>(coll);
     },
 
     /**

--- a/server/src/core/user/tests/fixtures.ts
+++ b/server/src/core/user/tests/fixtures.ts
@@ -1,0 +1,24 @@
+export const users = [
+  {
+    _id: 'donor1',
+    phone: '254700111111',
+    roles: ['donor']
+  },
+  {
+    _id: 'donor2',
+    phone: '254700222222',
+    roles: ['donor']
+  },
+  {
+    _id: 'middleman1',
+    phone: '254700333333',
+    roles: ['middleman'],
+    middlemanFor: ['donor1', 'donor2']
+  },
+  {
+    _id: 'beneficiary1',
+    phone: '254700444444',
+    roles: ['beneficiary'],
+    donors: ['donor2']
+  }
+];

--- a/server/src/core/user/tests/fixtures.ts
+++ b/server/src/core/user/tests/fixtures.ts
@@ -20,5 +20,11 @@ export const users = [
     phone: '254700444444',
     roles: ['beneficiary'],
     donors: ['donor2']
+  },
+  {
+    _id: 'donorMiddleman1',
+    phone: '254700555555',
+    roles: ['donor', 'middleman'],
+    middlemanFor: ['donor1']
   }
 ];

--- a/server/src/core/user/tests/user-service.test.ts
+++ b/server/src/core/user/tests/user-service.test.ts
@@ -1,0 +1,43 @@
+import { createDbUtils } from '../../test-util';
+import { users } from './fixtures';
+import { Users, UsersArgs } from '../user-service';
+import { User } from '../types';
+
+const DB = '_social_relief_user_service_tests_';
+const COLLECTION = 'users';
+
+
+describe('UserService tests', () => {
+  const dbUtils = createDbUtils(DB, COLLECTION);
+
+  beforeAll(async () => {
+    await dbUtils.setupDb();
+  });
+
+  afterAll(async () => {
+    await dbUtils.tearDown();
+  });
+
+  beforeEach(async () => {
+    await dbUtils.resetCollectionWith(users);
+  });
+
+  function usersColl() {
+    return dbUtils.getCollection<User>(COLLECTION);
+  }
+
+  describe('nominateBeneficiary', () => {
+    describe('when nominator is a middleman', () => {
+      test('should add represented donors to existing beneficiary', async () => {
+        const args: any = { transactions: {} };
+        const service = new Users(dbUtils.getDb(), args);
+        const res = await service.nominateBeneficiary({ phone: '254700444444', nominator: 'middleman1' });
+        expect(res._id).toBe('beneficiary1');
+        const updatedBeneficiary = await usersColl().findOne({ _id: res._id });
+        updatedBeneficiary.donors.sort((a, b) => a.localeCompare(b));
+        const expectedDonors = ['donor1', 'donor2']
+        expect(updatedBeneficiary.donors).toEqual(expectedDonors);
+      });
+    })
+  });
+});

--- a/server/src/core/user/tests/user-service.test.ts
+++ b/server/src/core/user/tests/user-service.test.ts
@@ -36,7 +36,7 @@ describe('UserService tests', () => {
     describe('when nominator is a middleman', () => {
       test('should add represented donors to existing beneficiary', async () => {
         const res = await createDefaultService().nominateBeneficiary({ phone: '254700444444', nominator: 'middleman1' });
-        expect(res._id).toBe('beneficiary1');
+        expect(res).toEqual({ _id: 'beneficiary1', phone: '254700444444' });
         const updatedBeneficiary = await usersColl().findOne({ _id: res._id });
         updatedBeneficiary.donors.sort((a, b) => a.localeCompare(b));
         const expectedDonors = ['donor1', 'donor2']
@@ -73,7 +73,7 @@ describe('UserService tests', () => {
     test('should add donor to the middlemanFor list of the middleman and add middleman role', async () => {
       const now = new Date();
       const res = await createDefaultService().nominateMiddleman({ phone: '254700222222', nominator: 'donor1' });
-      expect(res._id).toBe('donor2');
+      expect(res).toEqual({ _id: 'donor2', phone: '254700222222' });
       const updatedMiddleman = await usersColl().findOne({ _id: res._id });
       updatedMiddleman.roles.sort((a, b) => a.localeCompare(b));
       expect(updatedMiddleman.roles).toEqual(['donor', 'middleman']);
@@ -118,7 +118,7 @@ describe('UserService tests', () => {
     test('should return all the middleman for the specified user', async () => {
       const res = await createDefaultService().getAllMiddlemenByUser('donor1');
       res.sort((a, b) => a._id.localeCompare(b._id));
-      expect(res.map(u => u._id)).toEqual(['donorMiddleman1', 'middleman1']);
+      expect(res).toEqual([{ _id: 'donorMiddleman1', phone: '254700555555' }, { _id: 'middleman1', phone: '254700333333' }]);
     });
   });
 });

--- a/server/src/core/user/tests/user-service.test.ts
+++ b/server/src/core/user/tests/user-service.test.ts
@@ -1,6 +1,6 @@
-import { createDbUtils } from '../../test-util';
+import { createDbUtils, expectDatesAreClose } from '../../test-util';
 import { users } from './fixtures';
-import { Users, UsersArgs } from '../user-service';
+import { Users } from '../user-service';
 import { User } from '../types';
 
 const DB = '_social_relief_user_service_tests_';
@@ -27,17 +27,45 @@ describe('UserService tests', () => {
   }
 
   describe('nominateBeneficiary', () => {
+    function createService() {
+      const args: any = { transactions: {} };
+      const service = new Users(dbUtils.getDb(), args);
+      return service;
+    }
+
     describe('when nominator is a middleman', () => {
       test('should add represented donors to existing beneficiary', async () => {
-        const args: any = { transactions: {} };
-        const service = new Users(dbUtils.getDb(), args);
-        const res = await service.nominateBeneficiary({ phone: '254700444444', nominator: 'middleman1' });
+        const res = await createService().nominateBeneficiary({ phone: '254700444444', nominator: 'middleman1' });
         expect(res._id).toBe('beneficiary1');
         const updatedBeneficiary = await usersColl().findOne({ _id: res._id });
         updatedBeneficiary.donors.sort((a, b) => a.localeCompare(b));
         const expectedDonors = ['donor1', 'donor2']
         expect(updatedBeneficiary.donors).toEqual(expectedDonors);
       });
-    })
+
+      test('should also add middleman to beneficiary donors if middleman is also a donor', async () => {
+        const now = new Date();
+        const res = await createService().nominateBeneficiary({ phone: '254700444444', nominator: 'donorMiddleman1' });
+        expect(res._id).toBe('beneficiary1');
+        const updatedBeneficiary = await usersColl().findOne({ _id: res._id });
+        updatedBeneficiary.donors.sort((a, b) => a.localeCompare(b));
+        const expectedDonors = ['donor1', 'donor2', 'donorMiddleman1']
+        expect(updatedBeneficiary.donors).toEqual(expectedDonors);
+        expectDatesAreClose(now, updatedBeneficiary.updatedAt);
+      });
+
+      test('should create beneficiary if does not already exist', async () => {
+        const now = new Date();
+        const res = await createService().nominateBeneficiary({ phone: '254711222333', nominator: 'donorMiddleman1' });
+        const createdBeneficiary = await usersColl().findOne({ _id: res._id });
+        createdBeneficiary.donors.sort((a, b) => a.localeCompare(b));
+        expect(createdBeneficiary.phone).toBe('254711222333');
+        expect(createdBeneficiary.donors).toEqual(['donor1', 'donorMiddleman1']);
+        expect(createdBeneficiary.roles).toEqual(['beneficiary']);
+        expect(createdBeneficiary.addedBy).toBe('donorMiddleman1');
+        expectDatesAreClose(now, createdBeneficiary.createdAt);
+        expectDatesAreClose(now, createdBeneficiary.updatedAt);
+      });
+    });
   });
 });

--- a/server/src/core/user/tests/user-service.test.ts
+++ b/server/src/core/user/tests/user-service.test.ts
@@ -70,7 +70,7 @@ describe('UserService tests', () => {
   });
 
   describe('nominateMiddleman', () => {
-    test('should add donor to the middlemanFor list of the middleman and add middleman role', async () => {
+    test('should add donor to the list of donors the middleman represents and add middleman role', async () => {
       const now = new Date();
       const res = await createDefaultService().nominateMiddleman({ phone: '254700222222', nominator: 'donor1' });
       expect(res).toEqual({ _id: 'donor2', phone: '254700222222' });

--- a/server/src/core/user/tests/user-service.test.ts
+++ b/server/src/core/user/tests/user-service.test.ts
@@ -113,4 +113,12 @@ describe('UserService tests', () => {
       expectDatesAreClose(now, updatedMiddleman.updatedAt);
     });
   });
+
+  describe('getAllMiddlemenByUser', () => {
+    test('should return all the middleman for the specified user', async () => {
+      const res = await createDefaultService().getAllMiddlemenByUser('donor1');
+      res.sort((a, b) => a._id.localeCompare(b._id));
+      expect(res.map(u => u._id)).toEqual(['donorMiddleman1', 'middleman1']);
+    });
+  });
 });

--- a/server/src/core/user/tests/user-service.test.ts
+++ b/server/src/core/user/tests/user-service.test.ts
@@ -1,7 +1,7 @@
 import { createDbUtils, expectDatesAreClose } from '../../test-util';
 import { users } from './fixtures';
 import { Users } from '../user-service';
-import { User, DbUser } from '../types';
+import { DbUser } from '../types';
 
 const DB = '_social_relief_user_service_tests_';
 const COLLECTION = 'users';

--- a/server/src/core/user/tests/validator.test.ts
+++ b/server/src/core/user/tests/validator.test.ts
@@ -62,6 +62,23 @@ describe('validatesNominateBeneficiary', () => {
   });
 });
 
+describe('validateNominateMiddleman', () => {
+  it('should not throw error if inputs are valid', () => {
+    testValidationSucceeds(validators.validatesNominateMiddleman, [
+      { phone: '254729291091', nominator: 'nominator1' },
+      { phone: '254729311023', nominator: 'nominator1' }
+    ]);
+  });
+  it('should throw error if inputs are not valid', () => {
+    testValidationFails(validators.validatesNominateMiddleman, [
+      { phone: '25472929109', nominator: '' },
+      { phone: '+254729291091', nominator: {} },
+      { phone: '254829291091' },
+      { nominator: 'donor1' }
+    ]);
+  });
+});
+
 describe('validatesGetAllBeneficiariesByUser', () => {
   it('should not throw error if inputs are valid', () => {
     testValidationSucceeds(validators.validatesGetAllBeneficiariesByUser, [

--- a/server/src/core/user/tests/validator.test.ts
+++ b/server/src/core/user/tests/validator.test.ts
@@ -48,17 +48,16 @@ describe('validatesLogin', () => {
 describe('validatesNominateBeneficiary', () => {
   it('should not throw error if inputs are valid', () => {
     testValidationSucceeds(validators.validatesNominateBeneficiary, [
-      { phone: '254729291091', nominator: '254729311023' },
-      { phone: '254729311023', nominator: '254729291091' }
+      { phone: '254729291091', nominator: 'nominator1' },
+      { phone: '254729311023', nominator: 'nominator1' }
     ]);
   });
   it('should throw error if inputs are not valid', () => {
     testValidationFails(validators.validatesNominateBeneficiary, [
-      { phone: '25472929109', nominator: '2547293110232' },
-      { phone: '+254729291091', nominator: '254729311023' },
-      { phone: '254729291091', nominator: '+254729311023' },
+      { phone: '25472929109', nominator: '' },
+      { phone: '+254729291091', nominator: {} },
       { phone: '254829291091' },
-      { nominator: '254729311023' }
+      { nominator: 'donor1' }
     ]);
   });
 });

--- a/server/src/core/user/types.ts
+++ b/server/src/core/user/types.ts
@@ -6,7 +6,14 @@ export interface User {
   _id: string,
   phone: string,
   addedBy: string,
+  /**
+   * the donors from whom this beneficiary can receive funds
+   */
   donors: string[],
+  /**
+   * the donors on behalf of whom this middleman can add beneficiaries
+   */
+  middlemanFor?: string[],
   roles: UserRole[],
   createdAt: Date,
   updatedAt: Date

--- a/server/src/core/user/types.ts
+++ b/server/src/core/user/types.ts
@@ -77,8 +77,11 @@ export interface UserService {
    */
   nominateBeneficiary(args: UserNominateBeneficiaryArgs): Promise<User>;
   /**
-   * 
-   * @param args 
+   * nominates a user as a middleman to the nominating donor.
+   * A user account is created for the middleman if does not already exist
+   * @param args
+   * @params args.nominator ID donor nominating the middleman
+   * @params args.phone phone of the middleman being nominated
    */
   nominateMiddleman(args: UserNominateMiddlemanArgs): Promise<User>;
   /**
@@ -87,6 +90,11 @@ export interface UserService {
    * @param user
    */
   getAllBeneficiariesByUser(user: string): Promise<User[]>;
+  /**
+   * retrieves all middlemen for the specified user
+   * @param user id of the user whose middlemen to retrieve
+   */
+  getAllMiddlemenByUser(user: string): Promise<User[]>;
   /**
    * logs in the user if the credentials are valid,
    * generates a temporary access token for the user

--- a/server/src/core/user/types.ts
+++ b/server/src/core/user/types.ts
@@ -26,7 +26,7 @@ export interface DbUser extends User {
 /**
  * result of a nomination operation,
  * contains minimal data of the nominated user
- * that is safe for the nominator to se
+ * that is safe for the nominator to see
  */
 export interface NominatedUserResult {
   _id: string,

--- a/server/src/core/user/types.ts
+++ b/server/src/core/user/types.ts
@@ -23,6 +23,16 @@ export interface DbUser extends User {
   password: string
 }
 
+/**
+ * result of a nomination operation,
+ * contains minimal data of the nominated user
+ * that is safe for the nominator to se
+ */
+export interface NominatedUserResult {
+  _id: string,
+  phone: string
+};
+
 export interface AccessToken {
   _id: string,
   user: string,

--- a/server/src/core/user/types.ts
+++ b/server/src/core/user/types.ts
@@ -31,13 +31,17 @@ export interface AccessToken {
   expiresAt: Date
 };
 
-
 export interface UserCreateArgs {
   phone: string,
   password: string,
 };
 
 export interface UserNominateBeneficiaryArgs {
+  phone: string,
+  nominator: string,
+};
+
+export interface UserNominateMiddlemanArgs {
   phone: string,
   nominator: string,
 };
@@ -72,6 +76,11 @@ export interface UserService {
    * @param args 
    */
   nominateBeneficiary(args: UserNominateBeneficiaryArgs): Promise<User>;
+  /**
+   * 
+   * @param args 
+   */
+  nominateMiddleman(args: UserNominateMiddlemanArgs): Promise<User>;
   /**
    * retrieves all the users 
    * nominated by the specified user

--- a/server/src/core/user/user-service.ts
+++ b/server/src/core/user/user-service.ts
@@ -24,12 +24,13 @@ const SAFE_USER_PROJECTION = { _id: 1, phone: 1, addedBy: 1, donors: 1, roles: 1
  * @param user 
  */
 function getSafeUser(user: DbUser): User {
-  const { _id, phone, addedBy, donors, roles, createdAt, updatedAt } = user;
+  const { _id, phone, addedBy, donors, middlemanFor, roles, createdAt, updatedAt } = user;
   return {
     _id,
     phone,
     addedBy,
     donors,
+    middlemanFor,
     roles,
     createdAt,
     updatedAt

--- a/server/src/core/user/user-service.ts
+++ b/server/src/core/user/user-service.ts
@@ -168,11 +168,12 @@ export class Users implements UserService {
   }
 
   async nominateMiddleman(args: UserNominateMiddlemanArgs): Promise<User> {
+    validators.validatesNominateMiddleman(args);
     const { phone, nominator } = args;
     try {
       const nominatorUser = await this.collection.findOne({ _id: nominator, roles: 'donor' });
       if (!nominatorUser) throw createMiddlemanNominationFailedError();
-      
+
       const result = await this.collection.findOneAndUpdate(
         { phone },
         {

--- a/server/src/core/user/user-service.ts
+++ b/server/src/core/user/user-service.ts
@@ -17,6 +17,8 @@ const TOKEN_COLLECTION = 'access_tokens';
 const TOKEN_VALIDITY_MILLIS = 2 * 24 * 3600 * 1000; // 2 days
 
 const SAFE_USER_PROJECTION = { _id: 1, phone: 1, addedBy: 1, donors: 1, middlemanFor: 1, roles: 1, createdAt: 1, updatedAt: 1 };
+const NOMINATED_USER_PROJECTION = { _id: 1, phone: 1 };
+const RELATED_BENEFICIARY_PROJECTION = { _id: 1 };
 
 /**
  * removes fields that should
@@ -154,7 +156,7 @@ export class Users implements UserService {
             createdAt: new Date(),
           } 
         },
-        { upsert: true, returnOriginal: false, projection: SAFE_USER_PROJECTION }
+        { upsert: true, returnOriginal: false, projection: NOMINATED_USER_PROJECTION }
       );
       return getSafeUser(result.value);
     }
@@ -187,7 +189,7 @@ export class Users implements UserService {
             createdAt: new Date()
           }
         },
-        { upsert: true, returnOriginal: false, projection: SAFE_USER_PROJECTION }
+        { upsert: true, returnOriginal: false, projection: NOMINATED_USER_PROJECTION }
       );
       return getSafeUser(result.value);
     }
@@ -203,7 +205,7 @@ export class Users implements UserService {
   async getAllBeneficiariesByUser(userId: string): Promise<User[]> {
     validators.validatesGetAllBeneficiariesByUser(userId);
     try {
-      const result = await this.collection.find({ donors: { $in: [userId] } }, { projection: SAFE_USER_PROJECTION }).toArray();
+      const result = await this.collection.find({ donors: { $in: [userId] } }, { projection: RELATED_BENEFICIARY_PROJECTION }).toArray();
       return result;
     }
     catch (e) {
@@ -214,7 +216,7 @@ export class Users implements UserService {
   async getAllMiddlemenByUser(userId: string): Promise<User[]> {
     validateId(userId);
     try {
-      const result = await this.collection.find({ middlemanFor: { $in: [userId] } }, { projection: SAFE_USER_PROJECTION }).toArray();
+      const result = await this.collection.find({ middlemanFor: { $in: [userId] } }, { projection: NOMINATED_USER_PROJECTION }).toArray();
       return result;
     }
     catch (e) {

--- a/server/src/core/user/user-service.ts
+++ b/server/src/core/user/user-service.ts
@@ -8,7 +8,8 @@ import * as messages from '../messages';
 import { 
   AppError, createDbOpFailedError, createLoginError,
   createInvalidAccessTokenError, createResourceNotFoundError,
-  createUniquenessFailedError,createBeneficiaryNominationFailedError, createMiddlemanNominationFailedError } from '../error';
+  createUniquenessFailedError, createBeneficiaryNominationFailedError,
+  createMiddlemanNominationFailedError, isMongoDuplicateKeyError } from '../error';
 import { TransactionService, TransactionCreateArgs, Transaction, InitiateDonationArgs, SendDonationArgs } from '../payment';
 import * as validators from './validator'
 
@@ -107,7 +108,7 @@ export class Users implements UserService {
     }
     catch (e) {
       if (e instanceof AppError) throw e;
-      if (e.code == 11000 && e.message.indexOf(args.phone) >= 0) {
+      if (isMongoDuplicateKeyError(e, args.phone)) {
         throw createUniquenessFailedError(messages.ERROR_PHONE_ALREADY_IN_USE);
       }
 
@@ -162,7 +163,7 @@ export class Users implements UserService {
     }
     catch (e) {
       if (e instanceof AppError) throw e;
-      if (e.code == 11000 && e.message.indexOf(args.phone) >= 0) {
+      if (isMongoDuplicateKeyError(e, args.phone)) {
         throw createBeneficiaryNominationFailedError();
       }
       throw createDbOpFailedError(e.message);
@@ -195,7 +196,7 @@ export class Users implements UserService {
     }
     catch (e) {
       if (e instanceof AppError) throw e;
-      if (e.code == 11000 && e.message.indexOf(args.phone) >= 0) {
+      if (isMongoDuplicateKeyError(e, args.phone)) {
         throw createMiddlemanNominationFailedError();
       }
       throw createDbOpFailedError(e.message);

--- a/server/src/core/user/user-service.ts
+++ b/server/src/core/user/user-service.ts
@@ -154,7 +154,7 @@ export class Users implements UserService {
             createdAt: new Date(),
           } 
         },
-        { upsert: true, returnOriginal: false }
+        { upsert: true, returnOriginal: false, projection: SAFE_USER_PROJECTION }
       );
       return getSafeUser(result.value);
     }
@@ -187,7 +187,7 @@ export class Users implements UserService {
             createdAt: new Date()
           }
         },
-        { upsert: true, returnOriginal: false }
+        { upsert: true, returnOriginal: false, projection: SAFE_USER_PROJECTION }
       );
       return getSafeUser(result.value);
     }
@@ -298,7 +298,7 @@ export class Users implements UserService {
 
   private async getById(id: string): Promise<User> {
     try {
-      const user = await this.collection.findOne({ _id: id });
+      const user = await this.collection.findOne({ _id: id }, { projection: SAFE_USER_PROJECTION });
       if (!user) throw createResourceNotFoundError(messages.ERROR_USER_NOT_FOUND);
 
       return getSafeUser(user);

--- a/server/src/core/user/validation-schemas.ts
+++ b/server/src/core/user/validation-schemas.ts
@@ -68,6 +68,8 @@ export const nominateBeneficiaryInputSchema = joi.object().keys({
     }),
 });
 
+export const nominateMiddlemanInputSchema = nominateBeneficiaryInputSchema;
+
 export const getAllBeneficiariesInputSchema = userIdSchema;
 
 export const logoutInputSchema = userTokenIdSchema;

--- a/server/src/core/user/validation-schemas.ts
+++ b/server/src/core/user/validation-schemas.ts
@@ -61,12 +61,10 @@ export const nominateBeneficiaryInputSchema = joi.object().keys({
     }),
   nominator: joi.string()
     .required()
-    .pattern(/^2547\d{8}$/)
     .messages({
-      'any.required': `Nominator is required`,
+      'any.required': `Nominator id is required`,
       'string.base': 'Invalid type, nominator must be a string',
-      'string.empty': `Please enter nominator's phone number`,
-      'string.pattern.base': `Invalid nominator's phone number. Must start with 2547 and be 12 digit long`
+      'string.empty': `Nominator id is required`,
     }),
 });
 

--- a/server/src/core/user/validator.ts
+++ b/server/src/core/user/validator.ts
@@ -1,6 +1,7 @@
-import { UserCreateArgs, UserNominateBeneficiaryArgs, UserLoginArgs } from './types'
+import { UserCreateArgs, UserNominateBeneficiaryArgs, UserLoginArgs, UserNominateMiddlemanArgs } from './types'
 import { createValidationError } from '../error';
 import * as schemas from './validation-schemas';
+import { makeValidatorFromJoiSchema } from '../util';
 
 export const validatesCreate = (args: UserCreateArgs) => {
   const { error } = schemas.createInputSchema.validate(args);
@@ -16,6 +17,8 @@ export const validatesNominateBeneficiary = (args: UserNominateBeneficiaryArgs) 
   const { error } = schemas.nominateBeneficiaryInputSchema.validate(args);
   if (error) throw createValidationError(error.details[0].message);
 }
+
+export const validatesNominateMiddleman = makeValidatorFromJoiSchema<UserNominateMiddlemanArgs>(schemas.nominateMiddlemanInputSchema);
 
 export const validatesGetAllBeneficiariesByUser = (userId: string) => {
   const { error } = schemas.getAllBeneficiariesInputSchema.validate({ userId });

--- a/server/src/core/util/index.ts
+++ b/server/src/core/util/index.ts
@@ -1,5 +1,7 @@
 import { randomBytes } from 'crypto';
+import { ObjectSchema } from '@hapi/joi';
 import * as argon2 from 'argon2';
+import { createValidationError } from '../error';
 
 export function hashPassword(plain: string): Promise<string> {
   return argon2.hash(plain);
@@ -26,4 +28,11 @@ export function generateToken(): string {
 
 export function hasOnlyAllowedKeys (arg: any, allowedKeys: string[]): boolean {
   return arg ? !Object.keys(arg).some(key => !allowedKeys.includes(key)) : false;
+}
+
+export function makeValidatorFromJoiSchema<TArgs = any>(schema: ObjectSchema) {
+  return (args: TArgs) => {
+    const { error } = schema.validate(args);
+    if (error) throw createValidationError(error.details[0].message);
+  };
 }

--- a/server/src/core/util/index.ts
+++ b/server/src/core/util/index.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from 'crypto';
-import { ObjectSchema } from '@hapi/joi';
 import * as argon2 from 'argon2';
-import { createValidationError } from '../error';
+
+export * from './validation-util';
 
 export function hashPassword(plain: string): Promise<string> {
   return argon2.hash(plain);
@@ -28,11 +28,4 @@ export function generateToken(): string {
 
 export function hasOnlyAllowedKeys (arg: any, allowedKeys: string[]): boolean {
   return arg ? !Object.keys(arg).some(key => !allowedKeys.includes(key)) : false;
-}
-
-export function makeValidatorFromJoiSchema<TArgs = any>(schema: ObjectSchema) {
-  return (args: TArgs) => {
-    const { error } = schema.validate(args);
-    if (error) throw createValidationError(error.details[0].message);
-  };
 }

--- a/server/src/core/util/validation-util.ts
+++ b/server/src/core/util/validation-util.ts
@@ -1,0 +1,21 @@
+import * as joi from '@hapi/joi';
+import { createValidationError } from '../error';
+
+export function makeValidatorFromJoiSchema<TArgs = any>(schema: joi.Schema) {
+  return (args: TArgs) => {
+    const { error } = schema.validate(args);
+    if (error) throw createValidationError(error.details[0].message);
+  };
+}
+
+export const idValidationSchema = joi.string()
+  .required()
+  .pattern(/^[a-zA-Z0-9]+$/)
+  .messages({
+    'any.required': `id is required`,
+    'string.base': 'Invalid type, id must be a string',
+    'string.empty': `Please enter id`,
+    'string.pattern.base': `Invalid id. Must contain alphanumeric only`
+  });
+
+export const validateId = makeValidatorFromJoiSchema(idValidationSchema);

--- a/server/src/rest/routes/users.ts
+++ b/server/src/rest/routes/users.ts
@@ -23,7 +23,14 @@ users.get('/me', requireAuth(), wrapResponse(
   req => Promise.resolve(req.user)));
 
 users.post('/beneficiaries', requireAuth(), wrapResponse(
-  req => req.core.users.nominateBeneficiary(req.body)));
+  req => req.core.users.nominateBeneficiary({ phone: req.body.phone, nominator: req.user._id })));
 
 users.get('/beneficiaries', requireAuth(), wrapResponse(
   req => req.core.users.getAllBeneficiariesByUser(req.user._id)));
+
+users.post('/middlemen', requireAuth(), wrapResponse(
+  req => req.core.users.nominateMiddleman({ phone: req.body.phone, nominator: req.user._id })));
+
+users.get('/middlemen', requireAuth(), wrapResponse(
+  req => req.core.users.getAllMiddlemenByUser(req.user._id)));
+


### PR DESCRIPTION
Fixes issue #5

- [x] add `middlemanFor` field containing the list of donors a middleman represents
- [x] add represented donors to beneficiary when middleman adds a beneficiary
- [x] nominate middleman
- [x] validation
- [x] api endpoint
- [x] tests

I've also ensured that the `/middlemen` and `/beneficiaries` endpoints return data for the currently authenticated user. For some reason, it was getting it from the body, which is very bad for security. I think this is because the payload was changed when every method was forced to take one argument object in order fit in with the validation function. I think this move was a mistake.

I also made the `nominateBeneficiary()`, `nominateMiddleman()`, `getAllBeneficiariesByUser` and  `getAllMiddlemenByUser()` return minimal data about the related user so as not to leak sensitive data between users.