### PR TITLE
Set the app name to Social Relief

### DIFF
--- a/webapp/vue.config.js
+++ b/webapp/vue.config.js
@@ -1,8 +1,17 @@
 module.exports = {
   pwa: {
+    name: 'Social Relief',
     iconPaths: {
       favicon32: 'favicon.svg',
       favicon16: 'favicon.svg'
     }
+  },
+  chainWebpack: config => {
+    config
+      .plugin('html')
+      .tap(args => {
+        args[0].title = 'Social Relief';
+        return args;
+      });
   }
 }


### PR DESCRIPTION
## Related Issues

*List of issues fixed by this pull request*

Fixes #

## Description

The app's title in the browser title bar was still "webapp", I changed it to "Social Relief".
