### PR TITLE
Minor improvements to app

### DIFF
--- a/server/src/core/payment/flutterwave-payment-provider.ts
+++ b/server/src/core/payment/flutterwave-payment-provider.ts
@@ -69,7 +69,7 @@ function extractTransactionInfo(data: FlutterwaveTransactionInfo): ProviderTrans
       phone: `254${data.customer.phone_number.substring(1)}` // use internal instead of local format
     },
     status,
-    amount: data.charged_amount,
+    amount: data.amount,
     providerTransactionId: data.tx_ref,
     metadata: data,
     failureReason: status === 'failed' ? data.processor_response: ''

--- a/server/src/core/payment/transaction-service.ts
+++ b/server/src/core/payment/transaction-service.ts
@@ -67,12 +67,12 @@ export class Transactions implements TransactionService {
 
   async initiateDonation(user: User, args: InitiateDonationArgs): Promise<Transaction> {
     validators.validatesInitiateDonation({ userId: user._id, amount: args.amount });
-    args.amount = Math.floor(args.amount);
+    const amount = Math.floor(args.amount);
 
     const provider = this.receivingProvider();
 
     const trxArgs: TransactionCreateArgs = {
-      expectedAmount: args.amount,
+      expectedAmount: amount,
       to: user._id,
       from: '',
       fromExternal: true,
@@ -82,7 +82,7 @@ export class Transactions implements TransactionService {
     };
 
     try {
-      const requestResult = await provider.requestPaymentFromUser(user, args.amount);
+      const requestResult = await provider.requestPaymentFromUser(user, amount);
       trxArgs.providerTransactionId = requestResult.providerTransactionId;
       trxArgs.status = requestResult.status;
       trxArgs.metadata = requestResult.metadata;
@@ -98,11 +98,11 @@ export class Transactions implements TransactionService {
 
   async sendDonation(from: User, to: User, args: SendDonationArgs): Promise<Transaction> {
     validators.validatesSendDonation({ from: from._id, to: to._id, amountArg: args });
-    args.amount = Math.floor(args.amount);
-    
+    const amount = Math.floor(args.amount);
+
     const provider = this.sendingProvider();
     const trxArgs: TransactionCreateArgs = {
-      expectedAmount: args.amount,
+      expectedAmount: amount,
       to: to._id,
       from: from._id,
       fromExternal: false,
@@ -129,7 +129,7 @@ export class Transactions implements TransactionService {
       // transaction, then we'll simply mark this transaction record as failed
       // and that's enough to synchronize the system
       trx = await this.create(trxArgs);
-      const providerResult = await provider.sendFundsToUser(to, args.amount, { transaction: trx._id });
+      const providerResult = await provider.sendFundsToUser(to, amount, { transaction: trx._id });
       const updatedRes = await this.collection.findOneAndUpdate(
         { _id: trx._id },
         { 

--- a/server/src/core/payment/transaction-service.ts
+++ b/server/src/core/payment/transaction-service.ts
@@ -71,7 +71,7 @@ export class Transactions implements TransactionService {
     const provider = this.receivingProvider();
 
     const trxArgs: TransactionCreateArgs = {
-      expectedAmount: args.amount,
+      expectedAmount: Math.floor(args.amount),
       to: user._id,
       from: '',
       fromExternal: true,

--- a/server/src/core/payment/transaction-service.ts
+++ b/server/src/core/payment/transaction-service.ts
@@ -66,12 +66,13 @@ export class Transactions implements TransactionService {
   }
 
   async initiateDonation(user: User, args: InitiateDonationArgs): Promise<Transaction> {
-    validators.validatesInitiateDonation({ userId: user._id, amount: args.amount })
+    validators.validatesInitiateDonation({ userId: user._id, amount: args.amount });
+    args.amount = Math.floor(args.amount);
 
     const provider = this.receivingProvider();
 
     const trxArgs: TransactionCreateArgs = {
-      expectedAmount: Math.floor(args.amount),
+      expectedAmount: args.amount,
       to: user._id,
       from: '',
       fromExternal: true,
@@ -97,6 +98,8 @@ export class Transactions implements TransactionService {
 
   async sendDonation(from: User, to: User, args: SendDonationArgs): Promise<Transaction> {
     validators.validatesSendDonation({ from: from._id, to: to._id, amountArg: args });
+    args.amount = Math.floor(args.amount);
+    
     const provider = this.sendingProvider();
     const trxArgs: TransactionCreateArgs = {
       expectedAmount: args.amount,

--- a/webapp/src/components/donate-modal.vue
+++ b/webapp/src/components/donate-modal.vue
@@ -32,7 +32,9 @@
         <b-form-invalid-feedback class="text-center">
           {{ validationMessages[1] }}
         </b-form-invalid-feedback>
-        <span class="small">*: A transaction fee may be charged by the provider</span>
+        <div class="text-center">
+          <span class="small">A transaction fee may be charged by the provider</span>
+        </div>
       </b-form-group>
       <div class="text-center">
         <b-button type="submit" size="sm" variant="primary" class="custom-submit-button" @click.prevent="submitDonation">Submit</b-button>

--- a/webapp/src/components/donate-modal.vue
+++ b/webapp/src/components/donate-modal.vue
@@ -101,11 +101,7 @@ export default {
 
       if (!this.validationResults.includes(false)) {
         await this.donate({ amount: this.donationInputs.amount });
-        if (this.message.type === 'error') {
-          this.validationMessages = [this.message.message, this.message.message];
-          this.validationResults = [false, false];
-        }
-        else {
+        if (this.message.type !== 'error') {
           this.donationInputs = {
             phone: '',
             amount: 1000

--- a/webapp/src/components/donate-modal.vue
+++ b/webapp/src/components/donate-modal.vue
@@ -32,6 +32,7 @@
         <b-form-invalid-feedback class="text-center">
           {{ validationMessages[1] }}
         </b-form-invalid-feedback>
+        <span class="small">*: A transaction fee may be charged by the provider</span>
       </b-form-group>
       <div class="text-center">
         <b-button type="submit" size="sm" variant="primary" class="custom-submit-button" @click.prevent="submitDonation">Submit</b-button>

--- a/webapp/src/components/login-modal.vue
+++ b/webapp/src/components/login-modal.vue
@@ -152,14 +152,7 @@ export default {
       this.signInValidationResults = this.validateObj(this.signInCreds, this.signInValidationRules);
       if (!this.signInValidationResults.includes(false)) {
         await this.signUserIn({ phone: `254${this.signInCreds.phone}`, password: this.signInCreds.password });
-        if (!this.user) {
-          this.signInValidationMessages = [
-            'Login failed. Incorrect phone or password',
-            'Login failed. Incorrect phone or password'
-          ];
-          this.signInValidationResults = [false, false];
-        }
-        else {
+        if (this.user) {
           this.signInCreds = {
             phone: '',
             password: ''

--- a/webapp/src/components/sign-up-modal.vue
+++ b/webapp/src/components/sign-up-modal.vue
@@ -216,18 +216,7 @@ export default {
           email: this.signUpCreds.email,
         };
         await this.createUser(data);
-
-        if (!this.user) {
-          this.signUpValidationMessages = {
-            phone: 'Sign-up failed. Phone number or email already assigned to existing account',
-            password: '',
-            confirmedPassword: '',
-            name: '',
-            email: 'Sign-up failed. Phone number or email already assigned to existing account',
-          };
-          this.signUpValidationResults = { phone: false, password: null, confirmedPassword: null, name: null, email: false };
-        }
-        else {
+        if (this.user) {
           this.signUpCreds = {
             name: '',
             phone: '',

--- a/webapp/src/store/actions.ts
+++ b/webapp/src/store/actions.ts
@@ -80,6 +80,9 @@ const actions = wrapActions({
       'getTransactions'
     ].forEach((action) => dispatch(action));
   },
+  async resetMessage({ commit }) {
+    commit('unsetMessage');
+  },
   async clearData({ commit }) {
     [
       'unsetUser',

--- a/webapp/src/views/beneficiaries.vue
+++ b/webapp/src/views/beneficiaries.vue
@@ -195,7 +195,8 @@ export default {
       return '';
     },
     getDate(datetime) {
-      return new Date(datetime).toLocaleDateString() + ' ' + new Date(datetime).toLocaleTimeString();
+      const dateObj = new Date(datetime);
+      return dateObj.toLocaleDateString() + ' ' + dateObj.toLocaleTimeString();
     },
     getProgress(id) {
       const monthlyMax = 2000;
@@ -219,12 +220,7 @@ export default {
         default: 
           return '';
       }
-    }, 
-    // formatAmount(data) {
-    //   if (data.item.status === 'Success') return this.thousands_separator(data.item.amount)
-    //   return this.thousands_separator(data.item.expectedAmount)
-    // },
-
+    },
   },
   async mounted() {
     if (Auth.isAuthenticated()) {

--- a/webapp/src/views/beneficiaries.vue
+++ b/webapp/src/views/beneficiaries.vue
@@ -58,8 +58,8 @@
       </h5>
       <b-table v-if="distributionItems.length" :items="distributionItems" :fields="distributionFields" thead-class="bg-secondary text-white" striped hover stacked="sm" >
         <template v-slot:cell(amount)="data">
-          <span v-if="data.item.status==='Success'" class="text-secondary font-weight-bold"> {{ data.item.amount }}</span>
-          <span v-else class="text-secondary font-weight-bold"> {{ data.item.expectedAmount }} </span>
+          <span v-if="data.item.status==='Success'" class="text-secondary font-weight-bold"> {{ formatWithCommaSeparator(data.item.amount) }}</span>
+          <span v-else class="text-secondary font-weight-bold"> {{ formatWithCommaSeparator(data.item.expectedAmount) }} </span>
         </template>
         <template v-slot:cell(status)="data">
           <span v-if="data.item.status==='Success'" class="text-success font-weight-bold"> {{ data.item.status }} </span>
@@ -78,6 +78,7 @@
 import { mapState, mapGetters, mapActions } from 'vuex';
 import { Auth } from '../services';
 import { DEFAULT_SIGNED_OUT_PAGE } from '../router/defaults';
+import { formatWithCommaSeparator } from '../views/util';
 export default {
   name: 'beneficiaries',
   data() {
@@ -155,6 +156,7 @@ export default {
   },
   methods: {
     ...mapActions(['getCurrentUser','refreshData']),
+    formatWithCommaSeparator,
     handleExpand(beneficiary) {
       this.currentBeneficiary = beneficiary;
       this.$bvModal.show('beneficiary');
@@ -217,7 +219,12 @@ export default {
         default: 
           return '';
       }
-    }
+    }, 
+    // formatAmount(data) {
+    //   if (data.item.status === 'Success') return this.thousands_separator(data.item.amount)
+    //   return this.thousands_separator(data.item.expectedAmount)
+    // },
+
   },
   async mounted() {
     if (Auth.isAuthenticated()) {

--- a/webapp/src/views/beneficiaries.vue
+++ b/webapp/src/views/beneficiaries.vue
@@ -4,12 +4,12 @@
       <div class="">
         <h3 class="text-primary">Beneficiaries</h3>
         <p>
-          All nominees get up to <span class="text-secondary font-weight-bold">Ksh 2,000</span> monthly to purchase basic supplies during this trying period. Your contribution will go a long way touch the lives of <span class="text-secondary font-weight-bold">13,600+</span> people who
+          All beneficiaries get up to <span class="text-secondary font-weight-bold">Ksh 2,000</span> monthly to purchase basic supplies during this trying period. Your contribution will go a long way touch the lives of <span class="text-secondary font-weight-bold">13,600+</span> people who
           are currently enlisted as beneficiaries of this system. We at Social Relief want to say a big <span class="text-secondary font-weight-bold">THANK YOU</span> for your kindness and support.
         </p>
       </div>
       <div class="">
-        <h3 class="text-primary pb-3">My Nominees</h3>
+        <h3 class="text-primary pb-3">My Beneficiaries</h3>
         <div v-if="!beneficiaryItems.length" class="text-center">
           <p class="h2 font-weight-light">You don't have any beneficiaries yet...</p>
           <p class="">You can add a beneficiary directly, or nominate a middleman to add beneficiaries on your behalf.</p>

--- a/webapp/src/views/beneficiaries.vue
+++ b/webapp/src/views/beneficiaries.vue
@@ -2,14 +2,13 @@
   <b-container class="custom-container">
     <div class="ml-lg-5">
       <div class="">
-        <h3 class="text-primary">Beneficiaries</h3>
+        <h3 class="text-primary">My Beneficiaries</h3>
         <p>
           All beneficiaries get up to <span class="text-secondary font-weight-bold">Ksh 2,000</span> monthly to purchase basic supplies during this trying period. Your contribution will go a long way touch the lives of <span class="text-secondary font-weight-bold">13,600+</span> people who
           are currently enlisted as beneficiaries of this system. We at Social Relief want to say a big <span class="text-secondary font-weight-bold">THANK YOU</span> for your kindness and support.
         </p>
       </div>
       <div class="">
-        <h3 class="text-primary pb-3">My Beneficiaries</h3>
         <div v-if="!beneficiaryItems.length" class="text-center">
           <p class="h2 font-weight-light">You don't have any beneficiaries yet...</p>
           <p class="">You can add a beneficiary directly, or nominate a middleman to add beneficiaries on your behalf.</p>

--- a/webapp/src/views/beneficiaries.vue
+++ b/webapp/src/views/beneficiaries.vue
@@ -193,7 +193,7 @@ export default {
       return '';
     },
     getDate(datetime) {
-      return new Date(datetime).toLocaleDateString();
+      return new Date(datetime).toLocaleDateString() + ' ' + new Date(datetime).toLocaleTimeString();
     },
     getProgress(id) {
       const monthlyMax = 2000;

--- a/webapp/src/views/history.vue
+++ b/webapp/src/views/history.vue
@@ -14,7 +14,7 @@
           <div  align="end">
             <span class="font-weight-bold">Total amount distributed: </span><span class="font-weight-bold text-secondary">Ksh {{ totalAmountDistributed }}</span>
           </div>
-          
+
         </b-col>
       </b-row>
       <b-row v-if="!transactionItems.length" class="text-center ">
@@ -47,7 +47,7 @@
     </div>
     <b-modal
       id="transaction"
-      title="Transaction"
+      title="Transaction details"
       title-class="text-primary h3"
       centered
       hide-header-close

--- a/webapp/src/views/history.vue
+++ b/webapp/src/views/history.vue
@@ -9,10 +9,10 @@
         </b-col>
         <b-col>
           <div  align="end">
-            <span class="font-weight-bold">Total amount contributed: </span> <span class="font-weight-bold text-primary">Ksh {{ totalAmountDonated }}</span>
+            <span class="font-weight-bold">Total amount contributed: </span> <span class="font-weight-bold text-primary">Ksh {{ formatWithCommaSeparator(totalAmountDonated) }}</span>
           </div>
           <div  align="end">
-            <span class="font-weight-bold">Total amount distributed: </span><span class="font-weight-bold text-secondary">Ksh {{ totalAmountDistributed }}</span>
+            <span class="font-weight-bold">Total amount distributed: </span><span class="font-weight-bold text-secondary">Ksh {{ formatWithCommaSeparator(totalAmountDistributed) }}</span>
           </div>
 
         </b-col>
@@ -28,8 +28,8 @@
           <span class="font-weight-bold">{{ data.index + 1 }}.</span>
         </template>
         <template v-slot:cell(amount)="data">
-          <span v-if="data.item.type === 'Distribution'" class="font-weight-bold text-secondary">- {{  data.item.status === 'Success' ? data.item.amount : data.item.expectedAmount }}</span>
-          <span v-else class="font-weight-bold text-primary">+{{  data.item.status === 'Success' ? data.item.amount : data.item.expectedAmount }}</span>
+          <span v-if="data.item.type === 'Distribution'" class="font-weight-bold text-secondary">- {{  data.item.status === 'Success' ? formatWithCommaSeparator(data.item.amount) : formatWithCommaSeparator(data.item.expectedAmount) }}</span>
+          <span v-else class="font-weight-bold text-primary">+{{  data.item.status === 'Success' ? formatWithCommaSeparator(data.item.amount) : formatWithCommaSeparator(data.item.expectedAmount) }}</span>
         </template>
         <template v-slot:cell(type)="data">
           <span v-if="data.item.type === 'Distribution'" class="font-weight-bold text-secondary"> {{ data.item.type }}</span>
@@ -72,8 +72,8 @@
           <span v-else class="font-weight-bold text-primary"> {{ currentTransaction.type }}</span>
         <br/>
         <span class="font-weight-bold pr-2">Amount (Ksh):</span> 
-        <span v-if="currentTransaction.type === 'Distribution'" class="font-weight-bold text-secondary">-{{  currentTransaction.status === 'Success' ? currentTransaction.amount : currentTransaction.expectedAmount }}</span>
-        <span v-else class="font-weight-bold text-primary">+{{  currentTransaction.status === 'Success' ? currentTransaction.amount : currentTransaction.expectedAmount }}</span>
+        <span v-if="currentTransaction.type === 'Distribution'" class="font-weight-bold text-secondary">-{{  currentTransaction.status === 'Success' ? formatWithCommaSeparator(currentTransaction.amount) : formatWithCommaSeparator(currentTransaction.expectedAmount) }}</span>
+        <span v-else class="font-weight-bold text-primary">+{{  currentTransaction.status === 'Success' ? formatWithCommaSeparator(currentTransaction.amount) : formatWithCommaSeparator(currentTransaction.expectedAmount) }}</span>
         <br/>
         <span v-if="currentTransaction.type === 'Distribution'">
           <span class="font-weight-bold pr-2">From:</span> 
@@ -101,6 +101,7 @@
 import { mapState, mapActions, mapGetters } from 'vuex';
 import { Auth } from '../services';
 import { DEFAULT_SIGNED_OUT_PAGE } from '../router/defaults';
+import { formatWithCommaSeparator } from '../views/util';
 export default {
   name: 'history',
   data() {
@@ -174,6 +175,7 @@ export default {
   },
   methods: {
     ...mapActions(['getCurrentUser', 'refreshData']),
+    formatWithCommaSeparator,
     handleDonateBtn() {
       this.$bvModal.show('donate');
     },

--- a/webapp/src/views/history.vue
+++ b/webapp/src/views/history.vue
@@ -14,6 +14,7 @@
           <div  align="end">
             <span class="font-weight-bold">Total amount distributed: </span><span class="font-weight-bold text-secondary">Ksh {{ totalAmountDistributed }}</span>
           </div>
+          
         </b-col>
       </b-row>
       <b-row v-if="!transactionItems.length" class="text-center ">

--- a/webapp/src/views/history.vue
+++ b/webapp/src/views/history.vue
@@ -199,7 +199,8 @@ export default {
       this.$bvModal.hide('transaction');
     },
     getDate(datetime) {
-      return new Date(datetime).toLocaleDateString() + ' ' + new Date(datetime).toLocaleTimeString();
+      const dateObj = new Date(datetime);
+      return dateObj.toLocaleDateString() + ' ' + dateObj.toLocaleTimeString();
     },
     formatType(type) {
       if (type === 'donation') return 'Contribution';

--- a/webapp/src/views/history.vue
+++ b/webapp/src/views/history.vue
@@ -197,7 +197,7 @@ export default {
       this.$bvModal.hide('transaction');
     },
     getDate(datetime) {
-      return new Date(datetime).toLocaleDateString();
+      return new Date(datetime).toLocaleDateString() + ' ' + new Date(datetime).toLocaleTimeString();
     },
     formatType(type) {
       if (type === 'donation') return 'Contribution';

--- a/webapp/src/views/home/home.vue
+++ b/webapp/src/views/home/home.vue
@@ -92,8 +92,6 @@
               <b-card-text>
                 Contact us at <a href="mailto:socialrelief@manuscript.live">socialrelief@manuscript.live</a> 
               </b-card-text>
-
-              <!-- <b-button href="#" variant="primary">Go somewhere</b-button> -->
             </b-card>
           </div> 
       </section>

--- a/webapp/src/views/home/home.vue
+++ b/webapp/src/views/home/home.vue
@@ -35,7 +35,7 @@
       <section class="my-5 pt-5 text-center" id="beneficiaries">
         <h1 class="text-primary mb-5">The Beneficiaries</h1>
         <p>
-          All nominees get <span class="text-secondary font-weight-bold">Ksh 2,000</span> 
+          All beneficiaries get <span class="text-secondary font-weight-bold">Ksh 2,000</span> 
           to get basic supplies during this trying period. <br/>
           Here are some of the people whom your contribution will go along to help.
         </p>

--- a/webapp/src/views/home/home.vue
+++ b/webapp/src/views/home/home.vue
@@ -90,10 +90,10 @@
               img-src="https://picsum.photos/600/300/?image=25"
             >
               <b-card-text>
-                Some quick example text to build on the card title and make up the bulk of the card's content.
+                Contact us at <a href="mailto:socialrelief@manuscript.live">socialrelief@manuscript.live</a> 
               </b-card-text>
 
-              <b-button href="#" variant="primary">Go somewhere</b-button>
+              <!-- <b-button href="#" variant="primary">Go somewhere</b-button> -->
             </b-card>
           </div> 
       </section>

--- a/webapp/src/views/logged-in-structure.vue
+++ b/webapp/src/views/logged-in-structure.vue
@@ -28,7 +28,7 @@
           </b-nav>
         </b-col>
         <b-col>
-          <b-navbar toggleable="sm" variant="light" sticky>
+          <b-navbar toggleable="sm" variant="light" sticky style="margin-bottom: 1.5rem">
             <b-navbar-brand to="#" class="d-md-none">
               <img :src="imageUrl" width="150" alt="Social Relief Logo">
             </b-navbar-brand>

--- a/webapp/src/views/logged-in-structure.vue
+++ b/webapp/src/views/logged-in-structure.vue
@@ -19,7 +19,7 @@
             <b-nav-item to="/beneficiaries" exact exact-active-class="active">Beneficiaries</b-nav-item>
             <b-nav-item to="/middlemen" exact exact-active-class="active">Middlemen</b-nav-item>
             <b-nav-item to="/invitations" exact exact-active-class="active">Invitations</b-nav-item>
-            <b-nav-item to="/history" exact exact-active-class="active">History</b-nav-item>
+            <b-nav-item to="/history" exact exact-active-class="active">Transaction history</b-nav-item>
             <div class="small text-secondary mt-auto">
             <p>privacy policy</p>
             <p>terms of use</p>

--- a/webapp/src/views/logged-in-structure.vue
+++ b/webapp/src/views/logged-in-structure.vue
@@ -12,7 +12,7 @@
                 <div class="bg-secondary text-white rounded pl-3 pt-2">
                   <div class="font-weight-light">Current balance</div>
                   <div class="">KSH</div>
-                  <div class="h4">{{ totalAmountDonated - totalAmountDistributed }}</div>
+                  <div class="h4">{{ formatWithCommaSeparator(totalAmountDonated - totalAmountDistributed) }}</div>
                 </div>
               </div>
             </b-nav-text>
@@ -79,6 +79,7 @@
 <script>
 import { mapState, mapActions, mapGetters } from 'vuex';
 import HomeFooter from '../components/home-footer';
+import { formatWithCommaSeparator } from '../views/util';
 export default {
   name: 'logged-in-structure',
   components: { HomeFooter },
@@ -94,6 +95,7 @@ export default {
   },
   methods: {
     ...mapActions(['signUserOut', 'getCurrentUser', 'refreshData']),
+    formatWithCommaSeparator,
     async signOut() {
       await this.signUserOut();
     },

--- a/webapp/src/views/logged-in-structure.vue
+++ b/webapp/src/views/logged-in-structure.vue
@@ -114,6 +114,7 @@ export default {
             variant: 'danger',
             solid: true
           });
+          this.resetMessage();
           break;
         default:
           this.$bvToast.toast(this.message.message, {
@@ -121,7 +122,10 @@ export default {
             variant: 'info',
             solid: true
           });
+          this.resetMessage();
       }
+
+
     }
   }
 }

--- a/webapp/src/views/logged-in-structure.vue
+++ b/webapp/src/views/logged-in-structure.vue
@@ -37,7 +37,7 @@
 
             <b-collapse id="nav-collapse" is-nav>
               <b-nav class="h6 w-100 text-center" pills>
-                <b-nav-item to="/nominate" exact exact-active-class="active" class="col-sm-12 col-md-4 col-xl-2">Nominate</b-nav-item>
+                <b-nav-item to="/nominate" exact exact-active-class="active" class="col-sm-12 col-md-4 col-xl-3">Nominate people</b-nav-item>
                 <div class="col-sm-12 text-center d-md-none">
                   <b-nav-item to="/beneficiaries" exact exact-active-class="active">Beneficiaries</b-nav-item>
                   <b-nav-item to="/middlemen" exact exact-active-class="active">Middlemen</b-nav-item>
@@ -78,8 +78,6 @@
 </template>
 <script>
 import { mapState, mapActions, mapGetters } from 'vuex';
-import { Auth } from '../services';
-import { DEFAULT_SIGNED_OUT_PAGE } from '../router/defaults';
 import HomeFooter from '../components/home-footer';
 export default {
   name: 'logged-in-structure',

--- a/webapp/src/views/nominate.vue
+++ b/webapp/src/views/nominate.vue
@@ -2,7 +2,7 @@
   <b-container class="custom-container">
     <div class="ml-lg-5">
       <p>
-        <span class="h3 text-primary">Nominate</span>
+        <span class="h3 text-primary">Nominate people</span>
         <b-link to="invitations" class="text-body ml-5">View invitations</b-link>
       </p>
       <div class="bg-white rounded p-5 shadow-sm">

--- a/webapp/src/views/nominate.vue
+++ b/webapp/src/views/nominate.vue
@@ -110,6 +110,8 @@
 <script>
 import { mapState, mapActions } from 'vuex';
 import { validateObj } from '../views/util';
+import { Auth } from '../services';
+import { DEFAULT_SIGNED_OUT_PAGE } from '../router/defaults';
 export default {
   name: 'nominate',
   data() {
@@ -135,10 +137,10 @@ export default {
   },
   components: { },
   computed: {
-    ...mapState(['message']),
+    ...mapState(['user', 'message']),
   },
   methods: {
-    ...mapActions(['nominate']),
+    ...mapActions(['nominate', 'getCurrentUser','refreshData']),
     validateObj,
     hideDialog() {
       this.nomineeCreds = {
@@ -174,6 +176,16 @@ export default {
           this.$bvModal.show('nominate-success');
         }
       }
+    }
+  },
+  async mounted() {
+    if (Auth.isAuthenticated()) {
+      if (!this.user)
+        await this.getCurrentUser();
+      await this.refreshData();
+    }
+    else {
+      this.$router.push({ name: DEFAULT_SIGNED_OUT_PAGE });
     }
   }
 }

--- a/webapp/src/views/nominate.vue
+++ b/webapp/src/views/nominate.vue
@@ -33,9 +33,9 @@
             </b-col>
             <b-col>
               <b-input-group>
-                <template v-slot:prepend >
-                  <img :src="imageUrl" width="50" height="30" class="rounded-pill align-self-end" alt="Social Relief Logo">
-                </template>
+                <b-input-group-prepend>
+                  <b-button disabled class="custom-dialog-input-phone-prepend">+254</b-button>
+                </b-input-group-prepend>
                 <b-form-input 
                   v-model="nomineeCreds.phone"
                   type="text" 
@@ -136,9 +136,6 @@ export default {
   components: { },
   computed: {
     ...mapState(['message']),
-    imageUrl () {
-      return require(`@/assets/Flag_of_Kenya.png`);
-    }
   },
   methods: {
     ...mapActions(['nominate']),

--- a/webapp/src/views/nominate.vue
+++ b/webapp/src/views/nominate.vue
@@ -171,12 +171,8 @@ export default {
         }
 
         await this.nominate(data);
-        
-        if (this.message.type === 'error') {
-          this.validationMessages = [this.message.message, this.message.message, this.message.message];
-          this.validationResults = [false, false, false];
-        }
-        else {
+
+        if (this.message.type !== 'error') {
           this.validationResults = [null, null];
           this.$bvModal.show('nominate-success');
         }

--- a/webapp/src/views/util.ts
+++ b/webapp/src/views/util.ts
@@ -30,3 +30,7 @@ export const validateNamedRules = (obj: any, rules: { [name: string]: Rule }): N
     return res;
   }, {});
 };
+
+export const formatWithCommaSeparator = (num: Number): String => {
+  return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}

--- a/webapp/src/views/util.ts
+++ b/webapp/src/views/util.ts
@@ -32,5 +32,5 @@ export const validateNamedRules = (obj: any, rules: { [name: string]: Rule }): N
 };
 
 export const formatWithCommaSeparator = (num: Number): String => {
-  return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  return num.toLocaleString();
 }


### PR DESCRIPTION
## Related Issues

*List of issues fixed by this pull request*
- [x] When you try to login and the server returns an error, an error message is displayed below each field "Login failed. Incorrect phone or password". This error message is displayed regardless of the actual error that caused the request to fail. Fix: since server-side error message is displayed in toast, do not display server-side error message on form fields
- [x] Other forms also seem to display server-side error message below fields. You should only display validation errors below fields, not server errors. Let's leave server-side errors on the error toast that appears.
- [x] Replace the term "Nominate" in header with "Add people" or "Nominate people" or something like that
- [x] Replace the term "Nominee" with "Beneficiary" or "Middleman" depending on the context where possible.
- [x] In the "Beneficiaries" page, there's a main heading "Beneficiaries" and another heading "My nominees". Remove "My Nominees" heading. Rename "Beneficiaries" heading to "My Beneficiaries" heading in order to be consistent with "My Middlemen".
- [x] Numbers that represent amounts should have comma separators (i.e. balance, amount received/sent, etc. 1,000 instead of 1000). Input fields that accept amounts (e.g. the donate input) can be an exception to this.
- [x] In the Transactions details dialog, the Created At/Updated At fields should also display the time (hh:mm)
- [x] Ensure that only integer amounts are provided (this can be achieved using either validation, or casting the amount to an integer before storing it in the db). The Donate field in the client-side dialog should also reject decimal inputs.
- [x] In the "Nominate" form, replace the kenyan flag prefix with a `+254` prefix like we have in the login form
- [x] Slightly increase the bottom margin of the top header in the logged-in layout (i.e.  the one that contains the Donate button and Nominate link), it seems to close to the content below it.
- [x] Rename "History" in the sidebar with "Transaction history"
- [x] The transaction details dialog from the transactions table should have the heading "Transaction details" and not just "Transaction"
- [x] In the Donation dialog, add a note saying "A transaction fee may be charged by the provider".
- [x] In the Contact section, add the following message "Contact us at socialrelief@manuscript.live" (make the email address a mailto link).

Addresses #77 
