### PR TITLE
Make app more pwa-friendly

### DIFF
--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -4,6 +4,12 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <!-- Chrome, Firefox OS and Opera -->
+    <meta name="theme-color" content="#EF5A24">
+    <!-- Windows Phone -->
+    <meta name="msapplication-navbutton-color" content="#EF5A24">
+    <!-- iOS Safari -->
+    <meta name="apple-mobile-web-app-status-bar-style" content="#EF5A24">
     <link rel="icon" href="<%= BASE_URL %>favicon.svg">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
     <title><%= htmlWebpackPlugin.options.title %></title>

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -4,12 +4,6 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <!-- Chrome, Firefox OS and Opera -->
-    <meta name="theme-color" content="#EF5A24">
-    <!-- Windows Phone -->
-    <meta name="msapplication-navbutton-color" content="#EF5A24">
-    <!-- iOS Safari -->
-    <meta name="apple-mobile-web-app-status-bar-style" content="#EF5A24">
     <link rel="icon" href="<%= BASE_URL %>favicon.svg">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
     <title><%= htmlWebpackPlugin.options.title %></title>

--- a/webapp/vue.config.js
+++ b/webapp/vue.config.js
@@ -2,13 +2,7 @@ module.exports = {
   pwa: {
     name: 'Social Relief',
     manifestOptions: {
-      icons: [
-        {
-          src: './image/logo.jpg',
-          sizes: '1134x678',
-          type: 'image/jpg'
-        },
-      ]
+      icons: []
     },
     iconPaths: {
       favicon32: 'favicon.svg',

--- a/webapp/vue.config.js
+++ b/webapp/vue.config.js
@@ -2,11 +2,13 @@ module.exports = {
   pwa: {
     name: 'Social Relief',
     manifestOptions: {
-      icons: [
-        {
-          src: 'favicon.svg',
-        }
-      ],
+      icons: {
+        favicon32: 'favicon.svg',
+        favicon16: 'favicon.svg',
+        appleTouchIcon: 'favicon.svg',
+        maskIcon: 'favicon.svg',
+        msTileImage: 'favicon.svg',
+      },
     },
     iconPaths: {
       favicon32: 'favicon.svg',

--- a/webapp/vue.config.js
+++ b/webapp/vue.config.js
@@ -1,6 +1,13 @@
 module.exports = {
   pwa: {
     name: 'Social Relief',
+    icons: [
+        {
+            src: 'favicon.svg',
+            sizes: '192x192',
+            type: 'image/svg',
+        },
+    ],
     iconPaths: {
       favicon32: 'favicon.svg',
       favicon16: 'favicon.svg',
@@ -17,9 +24,6 @@ module.exports = {
       .plugin('html')
       .tap(args => {
         args[0].title = 'Social Relief';
-        args[0].appleTouchIcon = 'favicon.svg';
-        args[0].maskIcon = 'favicon.svg';
-        args[0].msTileImage = 'favicon.svg';
         return args;
       });
   }

--- a/webapp/vue.config.js
+++ b/webapp/vue.config.js
@@ -4,11 +4,9 @@ module.exports = {
     manifestOptions: {
       icons: [
         {
-          favicon32: 'favicon.svg',
-          favicon16: 'favicon.svg',
-          appleTouchIcon: 'favicon.svg',
-          maskIcon: 'favicon.svg',
-          msTileImage: 'favicon.svg',
+          src: './image/logo.jpg',
+          sizes: '1134x678',
+          type: 'image/jpg'
         },
       ]
     },

--- a/webapp/vue.config.js
+++ b/webapp/vue.config.js
@@ -1,12 +1,13 @@
 module.exports = {
   pwa: {
     name: 'Social Relief',
-    icons: [
-      {
-        src: 'favicon.svg',
-        type: 'image/svg'
-      }
-    ],
+    manifestOptions: {
+      icons: [
+        {
+          src: 'favicon.svg',
+        }
+      ],
+    },
     iconPaths: {
       favicon32: 'favicon.svg',
       favicon16: 'favicon.svg',

--- a/webapp/vue.config.js
+++ b/webapp/vue.config.js
@@ -2,13 +2,15 @@ module.exports = {
   pwa: {
     name: 'Social Relief',
     manifestOptions: {
-      icons: {
-        favicon32: 'favicon.svg',
-        favicon16: 'favicon.svg',
-        appleTouchIcon: 'favicon.svg',
-        maskIcon: 'favicon.svg',
-        msTileImage: 'favicon.svg',
-      },
+      icons: [
+        {
+          favicon32: 'favicon.svg',
+          favicon16: 'favicon.svg',
+          appleTouchIcon: 'favicon.svg',
+          maskIcon: 'favicon.svg',
+          msTileImage: 'favicon.svg',
+        },
+      ]
     },
     iconPaths: {
       favicon32: 'favicon.svg',

--- a/webapp/vue.config.js
+++ b/webapp/vue.config.js
@@ -3,7 +3,10 @@ module.exports = {
     name: 'Social Relief',
     iconPaths: {
       favicon32: 'favicon.svg',
-      favicon16: 'favicon.svg'
+      favicon16: 'favicon.svg',
+      appleTouchIcon: 'favicon.svg',
+      maskIcon: 'favicon.svg',
+      msTileImage: 'favicon.svg',
     },
     themeColor: '#EF5A24',
     msTileColor: '#EF5A24',

--- a/webapp/vue.config.js
+++ b/webapp/vue.config.js
@@ -2,11 +2,10 @@ module.exports = {
   pwa: {
     name: 'Social Relief',
     icons: [
-        {
-            src: 'favicon.svg',
-            sizes: '192x192',
-            type: 'image/svg',
-        },
+      {
+        src: 'favicon.svg',
+        type: 'image/svg'
+      }
     ],
     iconPaths: {
       favicon32: 'favicon.svg',

--- a/webapp/vue.config.js
+++ b/webapp/vue.config.js
@@ -7,7 +7,7 @@ module.exports = {
     },
     themeColor: '#EF5A24',
     msTileColor: '#EF5A24',
-    appleMobileWebAppCapable: '#EF5A24'
+    appleMobileWebAppStatusBarStyle: '#EF5A24'
   },
   chainWebpack: config => {
     config

--- a/webapp/vue.config.js
+++ b/webapp/vue.config.js
@@ -17,6 +17,9 @@ module.exports = {
       .plugin('html')
       .tap(args => {
         args[0].title = 'Social Relief';
+        args[0].appleTouchIcon = 'favicon.svg';
+        args[0].maskIcon = 'favicon.svg';
+        args[0].msTileImage = 'favicon.svg';
         return args;
       });
   }

--- a/webapp/vue.config.js
+++ b/webapp/vue.config.js
@@ -4,7 +4,10 @@ module.exports = {
     iconPaths: {
       favicon32: 'favicon.svg',
       favicon16: 'favicon.svg'
-    }
+    },
+    themeColor: '#EF5A24',
+    msTileColor: '#EF5A24',
+    appleMobileWebAppCapable: '#EF5A24'
   },
   chainWebpack: config => {
     config


### PR DESCRIPTION
## Related Issues

*List of issues fixed by this pull request*

Fixes #94 

## Description

*Provide an overview of the changes in this pull request*
This task aims to make social relief more pwa-friendly by changing the default green theme shown in the address bar on mobile phones. Additionally, the website's logo is used in place of the vue one when the user is prompted to add the app/website to their home screen. 