### PR TITLE
Fix error send donation to donor instead of beneficiary

### DIFF
--- a/server/src/core/payment/transaction-service.ts
+++ b/server/src/core/payment/transaction-service.ts
@@ -114,7 +114,7 @@ export class Transactions implements TransactionService {
     };
 
     try {
-      const transaction = await this.sendFundsToUser(from, trxArgs);
+      const transaction = await this.sendFundsToUser(to, trxArgs);
       return transaction;
     }
     catch (e) {


### PR DESCRIPTION
## Related Issues

*List of issues fixed by this pull request*

Fixes #

## Description

A regression bug caused the donation to be sent to the donor instead of beneficiary. This PR fixes that bug.
