### PR TITLE
Indicate when distribution results were for vetted beneficiaries

### DIFF
--- a/server/src/core/distribution/distribution-service.ts
+++ b/server/src/core/distribution/distribution-service.ts
@@ -27,6 +27,7 @@ export class DonationDistributions implements DonationDistributionService {
 
       const results: DonationDistributionResults = {
         _id: generateId(),
+        onlyVettedBeneficiaries,
         startedAt,
         finishedAt,
         distributions

--- a/server/src/core/distribution/tests/distribution-service.test.ts
+++ b/server/src/core/distribution/tests/distribution-service.test.ts
@@ -118,6 +118,8 @@ describe('DonationDistributionService tests', () => {
 
         // confirm the total is 4630 to ensure no other beneficiary was included in the distribution
         expect(distributions.reduce((a, b) => a + b.amount, 0)).toEqual(4630);
+
+        expect(savedData.onlyVettedBeneficiaries).toBe(true);
       });
     });
 

--- a/server/src/core/distribution/tests/distribution-service.test.ts
+++ b/server/src/core/distribution/tests/distribution-service.test.ts
@@ -97,6 +97,8 @@ describe('DonationDistributionService tests', () => {
         }
       ]);
 
+      expect(savedData.onlyVettedBeneficiaries).not.toBe(true);
+
       expect(lock.lock).toHaveBeenCalledTimes(1);
       expect(lock.unlock).toHaveBeenCalledTimes(1);
       await lock.ensureUnlocked();

--- a/server/src/core/distribution/types.ts
+++ b/server/src/core/distribution/types.ts
@@ -32,6 +32,7 @@ export interface DonationDistributionEvent {
 
 export interface DonationDistributionResults {
   _id: string;
+  onlyVettedBeneficiaries?: boolean;
   startedAt: Date;
   finishedAt: Date;
   distributions: DonationDistributionEvent[];


### PR DESCRIPTION
## Related Issues

*List of issues fixed by this pull request*

Fixes #143 

## Description

Added `onlyVettedBeneficiaries` boolean field to the distribution results to make it possible to distinguish between vetted and non-vetted distribution runs.
