### PR TITLE
Add count for total beneficiaries in computed stats

### DIFF
--- a/server/src/core/bootstrap.ts
+++ b/server/src/core/bootstrap.ts
@@ -76,7 +76,7 @@ export async function bootstrap(config: AppConfig): Promise<App> {
     webappBaseUrl: config.webappBaseUrl
   });
 
-  const stats = new Statistics(db, { transactions });
+  const stats = new Statistics(db);
 
   await users.createIndexes();
   await transactions.createIndexes();

--- a/server/src/core/payment/index.ts
+++ b/server/src/core/payment/index.ts
@@ -2,5 +2,5 @@ export * from './types';
 export { AtPaymentProvider, AT_PAYMENT_PROVIDER_NAME } from './at-payment-provider';
 export { ManualPaymentProvider, MANUAL_PAYMENT_PROVIDER_NAME } from './manual-payment-provider';
 export { FlutterwavePaymentProvider, FLUTTERWAVE_PAYMENT_PROVIDER_NAME } from './flutterwave-payment-provider';
-export { Transactions, TransactionsArgs } from './transaction-service';
+export { Transactions, TransactionsArgs, COLLECTION } from './transaction-service';
 export { PaymentProviders } from './provider-registry';

--- a/server/src/core/payment/transaction-service.ts
+++ b/server/src/core/payment/transaction-service.ts
@@ -7,7 +7,7 @@ import * as messages from '../messages';
 import * as validators from './validator';
 import { EventBus } from '../event';
 
-const COLLECTION = 'transactions';
+export const COLLECTION = 'transactions';
 
 export interface TransactionsArgs {
   paymentProviders: PaymentProviderRegistry;
@@ -354,16 +354,5 @@ export class Transactions implements TransactionService {
 
   private sendingProvider(): PaymentProvider {
     return this.providers.getPreferredForSending();
-  }
-
-  async aggregate(pipeline: any[]): Promise<any[]> {
-    try {
-      const results = await this.collection.aggregate(pipeline, { allowDiskUse: true }).toArray();
-      return results;
-    }
-    catch(e) {
-      rethrowIfAppError(e);
-      throw createDbOpFailedError(e.message);
-    }
   }
 }

--- a/server/src/core/payment/types.ts
+++ b/server/src/core/payment/types.ts
@@ -97,7 +97,6 @@ export interface TransactionService {
    * @param userId 
    */
   getUserBalance(userId: string): Promise<number>;
-  aggregate(pipeline: any[]): Promise<any[]>
 }
 
 export interface PaymentRequestResult {

--- a/server/src/core/stat/tests/fixtures.ts
+++ b/server/src/core/stat/tests/fixtures.ts
@@ -110,4 +110,39 @@ export const transactions = [
     toExternal: true,
     fromExternal: false
   }
-]
+];
+
+export const users = [
+  {
+    _id: 'id 1',
+    roles: ['donor']
+  },
+  {
+    _id: 'id 2',
+    roles: ['donor']
+  },
+  {
+    _id: 'id 3',
+    roles: ['beneficiary']
+  },
+  {
+    _id: 'id 4',
+    roles: ['beneficiary']
+  },
+  {
+    _id: 'id 5',
+    roles: ['beneficiary']
+  },
+  {
+    _id: 'id 6',
+    roles: ['beneficiary']
+  },
+  {
+    _id: 'id 7',
+    roles: ['beneficiary', 'middleman']
+  },
+  {
+    _id: '10',
+    roles: ['beneficiary']
+  }
+];

--- a/server/src/core/stat/types.ts
+++ b/server/src/core/stat/types.ts
@@ -1,9 +1,28 @@
 export interface Stats {
   _id: string,
+  /**
+   * total number of donors who have made a donation
+   */
   numContributors: number,
+  /**
+   * total amount donated (refunds are deducted)
+   */
   totalContributed: number,
-  numBeneficiaries: number, 
+  /**
+   * total number of beneficiaries who have received a donation
+   */
+  numRecipients: number, 
+  /**
+   * total amount distributed to beneficiaries
+   */
   totalDistributed: number,
+  /**
+   * total number of beneficiaries (whether they have received donations or not)
+   */
+  numBeneficiaries: number,
+  /**
+   * when the stats were last updated
+   */
   updatedAt: Date
 }
 

--- a/server/src/core/user/index.ts
+++ b/server/src/core/user/index.ts
@@ -1,2 +1,2 @@
 export { User, UserCreateArgs, UserService, UserRole, UserInvitationEventData } from './types';
-export { Users } from './user-service';
+export { Users, COLLECTION  } from './user-service';

--- a/server/src/core/user/types.ts
+++ b/server/src/core/user/types.ts
@@ -245,11 +245,6 @@ export interface UserService {
    */
   initiateRefund(user: string): Promise<Transaction>;
   /**
-   * 
-   * @param pipeline
-   */
-  aggregate(pipeline: any[]): Promise<any[]>;
-  /**
    * initiates a donation 
    * from anonymous user args.phone
    * @param args 

--- a/server/src/core/user/user-service.ts
+++ b/server/src/core/user/user-service.ts
@@ -19,7 +19,7 @@ import { Invitation, InvitationService, InvitationCreateArgs } from '../invitati
 import { EventBus, Event } from '../event';
 import { SystemLockService } from '../system-lock';
 
-const COLLECTION = 'users';
+export const COLLECTION = 'users';
 const TOKEN_COLLECTION = 'access_tokens';
 const TOKEN_VALIDITY_MILLIS = 2 * 24 * 3600 * 1000; // 2 days
 export const MAX_ALLOWED_REFUNDS = 3;
@@ -674,17 +674,6 @@ export class Users implements UserService {
     }
     catch (e) {
       console.error('Error occurred when handling event', event, e);
-    }
-  }
-
-  async aggregate(pipeline: any[]): Promise<any[]> {
-    try {
-      const results = await this.collection.aggregate(pipeline, { allowDiskUse: true }).toArray();
-      return results;
-    }
-    catch(e) {
-      if (e instanceof AppError) throw e;
-      throw createDbOpFailedError(e.message);
     }
   }
 

--- a/webapp/src/types.ts
+++ b/webapp/src/types.ts
@@ -146,6 +146,7 @@ export interface Stats {
   _id: string,
   numContributors: number,
   totalContributed: number,
+  numRecipients: number,
   numBeneficiaries: number, 
   totalDistributed: number,
   updatedAt: Date

--- a/webapp/src/views/beneficiaries.vue
+++ b/webapp/src/views/beneficiaries.vue
@@ -4,7 +4,7 @@
       <div class="">
         <h3 class="text-primary">My Beneficiaries</h3>
         <p>
-          All beneficiaries get up to <span class="text-secondary font-weight-bold">Ksh 2,000</span> monthly to purchase basic supplies during this trying period. Your contribution will go a long way touch the lives of <span class="text-secondary font-weight-bold">{{stats ? formatWithCommaSeparator(stats.numBeneficiaries) : 0}}+</span> people who
+          All beneficiaries get up to <span class="text-secondary font-weight-bold">Ksh 2,000</span> monthly to purchase basic supplies during this trying period. Your contribution will go a long way touch the lives of <span class="text-secondary font-weight-bold">{{stats ? formatWithCommaSeparator(stats.numBeneficiaries) : 0}}</span> people who
           are currently enlisted as beneficiaries of this system. We at Social Relief want to say a big <span class="text-secondary font-weight-bold">THANK YOU</span> for your kindness and support.
         </p>
       </div>

--- a/webapp/src/views/home/home.vue
+++ b/webapp/src/views/home/home.vue
@@ -31,7 +31,7 @@
               <p>Total amount distributed</p>
             </b-col>
             <b-col sm="12" md="3">
-              <p class="text-primary display-4 mb-0">{{stats ? formatWithCommaSeparator(stats.numBeneficiaries) : 0}}</p>
+              <p class="text-primary display-4 mb-0">{{stats ? formatWithCommaSeparator(stats.numRecipients) : 0}}</p>
               <p>Recipients so far</p>
             </b-col>
           </b-row>

--- a/webapp/src/views/home/home.vue
+++ b/webapp/src/views/home/home.vue
@@ -23,11 +23,11 @@
               <p>Contributors so far</p>
             </b-col>
             <b-col sm="12" md="3">
-              <p class="text-primary display-4 mb-0">{{stats ? (formatWithCommaSeparator(stats.totalContributed) + '+') : 0}}</p>
+              <p class="text-primary display-4 mb-0">{{stats ? (formatWithCommaSeparator(stats.totalContributed)) : 0}}</p>
               <p>Total amount contributed</p>
             </b-col>
             <b-col sm="12" md="3">
-              <p class="text-primary display-4 mb-0">{{stats ? (formatWithCommaSeparator(stats.totalDistributed) + '+') : 0}}</p>
+              <p class="text-primary display-4 mb-0">{{stats ? (formatWithCommaSeparator(stats.totalDistributed)) : 0}}</p>
               <p>Total amount distributed</p>
             </b-col>
             <b-col sm="12" md="3">
@@ -46,7 +46,7 @@
           the negative impact of the Covid-19 pandemic.
         </p>
         <p>Your contribution will go a long to touch the lives of</p>
-        <p class="text-primary display-4">{{ stats ? (formatWithCommaSeparator(stats.numBeneficiaries) + '+') : 0 }}</p>
+        <p class="text-primary display-4">{{ stats ? (formatWithCommaSeparator(stats.numBeneficiaries)) : 0 }}</p>
         <p>people who are currently enlisted as beneficiaries in this system.</p>
       </section>
 


### PR DESCRIPTION
## Related Issues

*List of issues fixed by this pull request*

Fixes #150

## Description

*Provide an overview of the changes in this pull request*

- Renamed the existing `stats.numBeneficiaries` to `stats.numRecipients` (counts the beneficiaries who have received a donation)
- Added a new `stats.numBeneficiaries` which counts total number of beneficiaries
- Remove the + next to stats figures (e.g. 5,000+) because we were not using it consistently, and also because we're currently presenting exact figures and not rounding.

I also made the controversial decision when refactoring to remove `UserService.aggregate()` and `TransactionService.aggregate()` and to just use `db.collection('users').aggregate()` and `db.collection('transactions').aggregate()` directly in the `StatsService`. I did this because I noticed that the stats service tests was mocking `TransactionService` and the mock implementation was simply calling `db.collection('transactions').aggregate()`, which is all that the original `TransactionService.aggregate()` does. So it felt like we're going through a lot of trouble just to create a non-useful layer on top the db aggregate method. And this method is only used by an internal statitistics compute code, not by any other service. So it didn't feel right to expose this method to other services.