### PR TITLE
Prefill donate modal with donation details upon visiting `donate` links

### DIFF
--- a/webapp/src/components/donate-anonymously-modal.vue
+++ b/webapp/src/components/donate-anonymously-modal.vue
@@ -137,8 +137,14 @@ export default {
   methods: {
     ...mapActions(['donateAnonymously']),
     showDialog() {
-      if (this.anonymousDonationDetails && this.anonymousDonationDetails.amount) {
-        this.donationInputs = this.anonymousDonationDetails;
+      if (this.anonymousDonationDetails) {
+        const { name, email, phone, amount } = this.anonymousDonationDetails;
+        this.donationInputs = { 
+          name: !name ? '' : name,
+          email: !email ? '' : email,
+          phone: !phone ? '' : phone,
+          amount: !amount ? 2000 : amount
+        };
       }
     },
     hideDialog() {
@@ -185,9 +191,6 @@ export default {
   },
   watch: {
     anonymousDonationDetails(donationDetails) {
-      if (donationDetails.amount) {
-        this.donationInputs = donationDetails;
-      }
       this.$bvModal.show('donate-anonymously');
     }
   }

--- a/webapp/src/components/donate-anonymously-modal.vue
+++ b/webapp/src/components/donate-anonymously-modal.vue
@@ -190,8 +190,10 @@ export default {
     }
   },
   watch: {
-    anonymousDonationDetails(donationDetails) {
-      this.$bvModal.show('donate-anonymously');
+    anonymousDonationDetails() {
+      if (this.$route.name === 'home') {
+        this.$bvModal.show('donate-anonymously');
+      }
     }
   }
 }

--- a/webapp/src/components/donate-anonymously-modal.vue
+++ b/webapp/src/components/donate-anonymously-modal.vue
@@ -137,7 +137,7 @@ export default {
   methods: {
     ...mapActions(['donateAnonymously']),
     showDialog() {
-      if (this.anonymousDonationDetails) {
+      if (this.anonymousDonationDetails && this.anonymousDonationDetails.amount) {
         this.donationInputs = this.anonymousDonationDetails;
       }
     },
@@ -185,7 +185,9 @@ export default {
   },
   watch: {
     anonymousDonationDetails(donationDetails) {
-      this.donationInputs = donationDetails;
+      if (donationDetails.amount) {
+        this.donationInputs = donationDetails;
+      }
       this.$bvModal.show('donate-anonymously');
     }
   }

--- a/webapp/src/components/donate-anonymously-modal.vue
+++ b/webapp/src/components/donate-anonymously-modal.vue
@@ -186,7 +186,6 @@ export default {
   watch: {
     anonymousDonationDetails(donationDetails) {
       this.donationInputs = donationDetails;
-      console.log(this.donationInputs);
       this.$bvModal.show('donate-anonymously');
     }
   }

--- a/webapp/src/components/donate-anonymously-modal.vue
+++ b/webapp/src/components/donate-anonymously-modal.vue
@@ -8,6 +8,7 @@
     hide-footer
     no-stacking
     @hidden="hideDialog()"
+    @shown="showDialog()"
     content-class="rounded"
     >
     <template v-slot:modal-header>
@@ -125,7 +126,7 @@ export default {
     }
   },
   computed: {
-    ...mapState(['user', 'message']),
+    ...mapState(['user', 'message', 'anonymousDonationDetails']),
     imageUrl () {
       return require(`@/assets/Social Relief Logo_1.svg`);
     },
@@ -135,6 +136,11 @@ export default {
   },
   methods: {
     ...mapActions(['donateAnonymously']),
+    showDialog() {
+      if (this.anonymousDonationDetails) {
+        this.donationInputs = this.anonymousDonationDetails;
+      }
+    },
     hideDialog() {
       this.donationInputs = {
         amount: 2000,
@@ -177,6 +183,13 @@ export default {
       }
     }
   },
+  watch: {
+    anonymousDonationDetails(donationDetails) {
+      this.donationInputs = donationDetails;
+      console.log(this.donationInputs);
+      this.$bvModal.show('donate-anonymously');
+    }
+  }
 }
 </script>
 <style lang="scss" scoped>

--- a/webapp/src/components/donate-modal.vue
+++ b/webapp/src/components/donate-modal.vue
@@ -66,7 +66,7 @@ export default {
     }
   },
   computed: {
-    ...mapState(['user', 'message'])
+    ...mapState(['user', 'message', 'anonymousDonationDetails'])
   },
   methods: {
     ...mapActions(['donate']),
@@ -89,6 +89,9 @@ export default {
     setModalData() {
       if (this.user) {
         this.donationInputs.phone = this.user.phone.substring(3);
+      }
+      if (this.anonymousDonationDetails.amount) {
+        this.donationInputs.amount = this.anonymousDonationDetails.amount;
       }
     },
     async submitDonation() {

--- a/webapp/src/store/actions.ts
+++ b/webapp/src/store/actions.ts
@@ -97,6 +97,9 @@ const actions = wrapActions({
     }
     
   },
+  async setAnonymousDonationDetails({ commit }, { name, phone, email, amount }: {amount: number; name: string; phone: string; email: string }) {
+    commit('setAnonymousDonationDetails', { name, phone, email, amount });
+  },
   async initiateRefund({ commit, state }) {
     if (state.user) {
       const trx = await Refunds.initiateRefund();
@@ -176,7 +179,7 @@ const actions = wrapActions({
       'unsetCurrentInvitation',
       'unsetLastPaymentRequest',
       'unsetMessage',
-      'unsetStats'
+      'unsetStats',
     ].forEach((mutation) => commit(mutation));
   }
 });

--- a/webapp/src/store/actions.ts
+++ b/webapp/src/store/actions.ts
@@ -97,7 +97,7 @@ const actions = wrapActions({
     }
     
   },
-  async setAnonymousDonationDetails({ commit }, { name, phone, email, amount }: {amount: number; name: string; phone: string; email: string }) {
+  async setAnonymousDonationDetails({ commit }, { name, phone, email, amount }: {amount: number; name?: string; phone?: string; email?: string }) {
     commit('setAnonymousDonationDetails', { name, phone, email, amount });
   },
   async initiateRefund({ commit, state }) {

--- a/webapp/src/store/index.ts
+++ b/webapp/src/store/index.ts
@@ -12,6 +12,7 @@ const state: AppState = {
   user: undefined,
   anonymousUser: undefined,
   newUser: undefined,
+  anonymousDonationDetails: undefined,
   beneficiaries: [],
   middlemen: [],
   transactions: [],

--- a/webapp/src/store/mutations.ts
+++ b/webapp/src/store/mutations.ts
@@ -59,7 +59,13 @@ const mutations: MutationTree<AppState> = {
     state.anonymousUser = user;
   },
   unsetAnonymousUser(state) {
-    state.anonymousUser = undefined
+    state.anonymousUser = undefined;
+  },
+  setAnonymousDonationDetails(state, donationDetails) {
+    state.anonymousDonationDetails = donationDetails;
+  },
+  unsetAnonymousDonationDetails(state) {
+    state.anonymousDonationDetails = undefined;
   },
   setNewUser(state, newUser) {
     state.newUser = newUser;

--- a/webapp/src/types.ts
+++ b/webapp/src/types.ts
@@ -166,6 +166,7 @@ export interface FAQ {
 export interface AppState {
   user?: User;
   anonymousUser?: User;
+  anonymousDonationDetails?: AnonymousDonateArgs;
   newUser?: User;
   beneficiaries: User[];
   middlemen: User[];

--- a/webapp/src/views/beneficiaries.vue
+++ b/webapp/src/views/beneficiaries.vue
@@ -123,7 +123,7 @@ export default {
    }
   }, 
   computed: {
-    ...mapState(['beneficiaries', 'user', 'middlemen', 'stats']),
+    ...mapState(['beneficiaries', 'user', 'middlemen', 'stats', 'anonymousDonationDetails']),
     ...mapGetters(['distributions']),
     beneficiaryItems() {
       return this.beneficiaries.map(b => {
@@ -229,10 +229,15 @@ export default {
         await this.getCurrentUser();
       await this.refreshData();
       await this.getStats();
+
+      if (this.anonymousDonationDetails) {
+        this.$bvModal.hide('donate-anonymously');
+        this.$bvModal.show('donate');
+      }
     }
     else {
       this.$router.push({ name: DEFAULT_SIGNED_OUT_PAGE });
     }
-  }
+  },
 }
 </script>

--- a/webapp/src/views/home/home.vue
+++ b/webapp/src/views/home/home.vue
@@ -1,5 +1,11 @@
 <template>
     <b-container fluid="sm" class="w-md-75">
+      <b-alert show variant="danger" class="mt-3">
+        <h4 class="alert-heading">Downtime with M-PESA!</h4>
+        <p>
+          We are experiencing downtime with M-PESA push payments. Consider using the Paybill option or paying via card.
+        </p>
+      </b-alert>
       <section class="my-5">
         <div>
           <h3 class="text-secondary">

--- a/webapp/src/views/home/home.vue
+++ b/webapp/src/views/home/home.vue
@@ -175,9 +175,9 @@ export default {
       await this.getNewUser(this.$route.params.id);
       if (this.message.type !== 'error') this.$bvModal.show('sign-up');
     }
-    else if (this.$route.name === 'home' && this.$route.query.donate && this.$route.query.name && this.$route.query.email && this.$route.query.phone && this.$route.query.amount) {
-      const { name, email, phone, amount } = this.$route.query;
-      await this.setAnonymousDonationDetails({ name, email, phone, amount: Number(amount) });
+    else if (this.$route.name === 'home' && this.$route.query.donate) {
+      const { n, e, p, a } = this.$route.query;
+      await this.setAnonymousDonationDetails({ name: n, email: e, phone: p, amount: a ? Number(a) : undefined });
     }
     await this.getStats();
   },

--- a/webapp/src/views/home/home.vue
+++ b/webapp/src/views/home/home.vue
@@ -11,7 +11,7 @@
             <h6 class="text-primary">Click the button below to make your contribution.</h6>
           </div>
           <div class="pb-3">
-            <b-button pill variant="primary" class="px-5" @click="handleDonateBtn()" :ref="'donateBtn'" :key="donateBtnKey">Donate</b-button>
+            <b-button pill variant="primary" class="px-5" @click="handleDonateBtn()">Donate</b-button>
           </div>
         </div>
       

--- a/webapp/src/views/home/home.vue
+++ b/webapp/src/views/home/home.vue
@@ -11,7 +11,7 @@
             <h6 class="text-primary">Click the button below to make your contribution.</h6>
           </div>
           <div class="pb-3">
-            <b-button pill variant="primary" class="px-5" @click="handleDonateBtn()">Donate</b-button>
+            <b-button pill variant="primary" class="px-5" @click="handleDonateBtn()" :ref="'donateBtn'" :key="donateBtnKey">Donate</b-button>
           </div>
         </div>
       
@@ -141,6 +141,11 @@ import { formatWithCommaSeparator } from '../../views/util';
 import { mapState, mapActions } from 'vuex';
 export default {
   name: 'home',
+  data() {
+    return {
+      donateBtnKey: 0
+    }
+  },
   computed: {
     ...mapState(['newUser', 'message', 'stats', 'testimonials', 'faqs']),
     beneficiaryImages() {
@@ -159,19 +164,23 @@ export default {
     },
   },
   methods: {
-    ...mapActions(['getNewUser', 'getStats']),
+    ...mapActions(['getNewUser', 'getStats', 'setAnonymousDonationDetails']),
     formatWithCommaSeparator,
     handleDonateBtn() {
       this.$bvModal.show('donate-anonymously');
-    }
+    },
   },
   async mounted(){
     if (this.$route.name === 'signup-new-user' && this.$route.params.id && this.$route.params.id.length) {
       await this.getNewUser(this.$route.params.id);
       if (this.message.type !== 'error') this.$bvModal.show('sign-up');
     }
-    else await this.getStats();
-  } 
+    else if (this.$route.name === 'home' && this.$route.query.donate && this.$route.query.name && this.$route.query.email && this.$route.query.phone && this.$route.query.amount) {
+      const { name, email, phone, amount } = this.$route.query;
+      await this.setAnonymousDonationDetails({ name, email, phone, amount: Number(amount) });
+    }
+    await this.getStats();
+  },
 }
 </script>
 <style lang="scss" scoped>

--- a/webapp/src/views/home/home.vue
+++ b/webapp/src/views/home/home.vue
@@ -1,9 +1,9 @@
 <template>
     <b-container fluid="sm" class="w-md-75">
-      <b-alert show variant="danger" class="mt-3">
-        <h4 class="alert-heading">Downtime with M-PESA!</h4>
+      <b-alert show variant="warning" class="mt-3">
+        <h4 class="alert-heading">Downtime with M-PESA push!</h4>
         <p>
-          We are experiencing downtime with M-PESA push payments. Consider using the Paybill option or paying via card.
+          We are experiencing downtime with M-PESA push payments. Consider using the Paybill option or paying via card when you check out.
         </p>
       </b-alert>
       <section class="my-5">

--- a/webapp/src/views/logged-in-structure.vue
+++ b/webapp/src/views/logged-in-structure.vue
@@ -81,6 +81,16 @@
           >
             This account is blocked from making donations. Reason: {{ user.transactionsBlockedReason }}
           </div>
+          <b-container class="custom-container">
+            <div class="ml-lg-5">
+              <b-alert show variant="warning" class="mt-3">
+                <h4 class="alert-heading">Downtime with M-PESA push!</h4>
+                <p>
+                  We are experiencing downtime with M-PESA push payments. Consider using the Paybill option or paying via card when you check out.
+                </p>
+              </b-alert>
+            </div>
+          </b-container>
           <router-view />
         </b-col>
       </b-row>


### PR DESCRIPTION
## Related Issues

*List of issues fixed by this pull request*

Fixes #159 #165 

## Description

*Provide an overview of the changes in this pull request*
This task aims to set up the donate modal in such a way that it is prefilled with donation details when a user follows either one of the following links: `https://socialrelief.co?donate=true`, `https://socialrelief.co?donate=true&name=John+Doe&email=johndoe@mailer.com&phone=721332332&amount=5000`