### PR TITLE
Add social relief's twitter link on homepage

### DIFF
--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -48,5 +48,6 @@
       })();
     </script>
     <!--End of Tawk.to Script-->
+    <script src="https://use.fontawesome.com/33aac5afed.js"></script>
   </body>
 </html>

--- a/webapp/src/views/home/home.vue
+++ b/webapp/src/views/home/home.vue
@@ -1,11 +1,5 @@
 <template>
     <b-container fluid="sm" class="w-md-75">
-      <b-alert show variant="warning" class="mt-3">
-        <h4 class="alert-heading">Downtime with M-PESA push!</h4>
-        <p>
-          We are experiencing downtime with M-PESA push payments. Consider using the Paybill option or paying via card when you check out.
-        </p>
-      </b-alert>
       <section class="my-5">
         <div>
           <h3 class="text-secondary">

--- a/webapp/src/views/logged-in-structure.vue
+++ b/webapp/src/views/logged-in-structure.vue
@@ -81,16 +81,6 @@
           >
             This account is blocked from making donations. Reason: {{ user.transactionsBlockedReason }}
           </div>
-          <b-container class="custom-container">
-            <div class="ml-lg-5">
-              <b-alert show variant="warning" class="mt-3">
-                <h4 class="alert-heading">Downtime with M-PESA push!</h4>
-                <p>
-                  We are experiencing downtime with M-PESA push payments. Consider using the Paybill option or paying via card when you check out.
-                </p>
-              </b-alert>
-            </div>
-          </b-container>
           <router-view />
         </b-col>
       </b-row>

--- a/webapp/src/views/logged-out-structure.vue
+++ b/webapp/src/views/logged-out-structure.vue
@@ -14,6 +14,7 @@
             <b-nav-item to="/#faq" >FAQ</b-nav-item>
             <b-nav-item to="/#about-us">About Us</b-nav-item>
             <b-nav-item to="/#contact-us">Contact Us</b-nav-item>
+            <b-nav-item href="https://twitter.com/SocialReliefKe" target="_blank"><a href="#"><i class="fab fa-twitter fa-lg"></i></a></b-nav-item>
             <b-nav-item to="#" @click="handleLoginAndSignUpBtnClick">
               <b-button size="sm" pill variant="primary">Login / Sign Up</b-button>
             </b-nav-item>

--- a/webapp/src/views/logged-out-structure.vue
+++ b/webapp/src/views/logged-out-structure.vue
@@ -14,7 +14,7 @@
             <b-nav-item to="/#faq" >FAQ</b-nav-item>
             <b-nav-item to="/#about-us">About Us</b-nav-item>
             <b-nav-item to="/#contact-us">Contact Us</b-nav-item>
-            <b-nav-item href="https://twitter.com/SocialReliefKe" target="_blank"><a href="#"><i class="fab fa-twitter fa-lg"></i></a></b-nav-item>
+            <b-nav-item href="https://twitter.com/SocialReliefKe" target="_blank"><i class="fab fa-twitter fa-lg" style="color: #9D1A69 !important"></i></b-nav-item>
             <b-nav-item to="#" @click="handleLoginAndSignUpBtnClick">
               <b-button size="sm" pill variant="primary">Login / Sign Up</b-button>
             </b-nav-item>


### PR DESCRIPTION
## Related Issues

*List of issues fixed by this pull request*

Fixes #166

## Description

*Provide an overview of the changes in this pull request*
This task is aimed at incorporating a link to the social relief twitter account in the navigation bar on the home page. Moreover, the warning message found on both "logged-in" and "logged-out" view has been removed as the issue of M-PESA push seems to have been resolved.
