### PR TITLE
Fix error processing flutterwave transfer notification

### DIFF
--- a/server/src/core/payment/flutterwave-payment-provider.ts
+++ b/server/src/core/payment/flutterwave-payment-provider.ts
@@ -63,10 +63,13 @@ interface FlutterwaveTransactionResponse {
 function extractTransactionInfo(data: FlutterwaveTransactionInfo): ProviderTransactionInfo {
   const status: TransactionStatus = data.status === 'successful' ? 'success' :
       data.status === 'failed' ? 'failed' : 'pending';
+  
+  // phone number comes in in 07... format, strip the 0
+  const flwPhone = data.customer?.phone_number?.substring(1);
 
   return {
     userData: {
-      phone: `254${data.customer.phone_number.substring(1)}` // use internal instead of local format
+      phone: flwPhone ? `254${flwPhone}` : '' // convert to internal 254 format
     },
     status,
     amount: data.amount,

--- a/server/src/webhooks/flutterwave.ts
+++ b/server/src/webhooks/flutterwave.ts
@@ -11,6 +11,7 @@ flutterwaveRoutes.post('/', (req: AppRequest, res) => {
     .then(_ => res.status(200).send())
     .catch(e => {
       console.error('Flutterwave notification error', e);
+      console.error('Notification payload', JSON.stringify(req.body, null, 2));
       res.status(400).send();
     });
 });


### PR DESCRIPTION
## Related Issues

*List of issues fixed by this pull request*

Fixes #168 

## Description

*Provide an overview of the changes in this pull request*

Do not attempt to read from data.customer.phone_number if it doesn't exist.

Also prints flutterwave notification payload in case of an error.
