### PR TITLE
Bulk messaging

### DIFF
--- a/server/src/admin-cli/admin-cli.ts
+++ b/server/src/admin-cli/admin-cli.ts
@@ -1,8 +1,8 @@
 import { App } from '../core';
 import { prompt } from 'inquirer';
 import { prompts } from './prompts';
-import { addVettedBeneficiaryCmd, sendBulkMessageCmd, upgradeUnvettedBeneficiaryCmd, verifyVettedBeneficiaryCmd } from './commands';
-import { ADD_VETTED_BENEFICIARY, SEND_BULK_MESSAGE, UPGRADE_UNVETTED_BENEFICIARY, VERIFY_VETTED_BENEFICIARY } from './command-names';
+import { addVettedBeneficiaryCmd, sendBulkMessageCmd, showUserInfoCmd, upgradeUnvettedBeneficiaryCmd, verifyVettedBeneficiaryCmd } from './commands';
+import { ADD_VETTED_BENEFICIARY, SEND_BULK_MESSAGE, SHOW_USER_INFO, UPGRADE_UNVETTED_BENEFICIARY, VERIFY_VETTED_BENEFICIARY } from './command-names';
 
 export async function runAdminCLI(app: App) {
   async function cliLoop() {
@@ -22,6 +22,9 @@ export async function runAdminCLI(app: App) {
           break;
         case SEND_BULK_MESSAGE:
           await sendBulkMessageCmd(app);
+          break;
+        case SHOW_USER_INFO:
+          await showUserInfoCmd(app);
           break;
       }
     }

--- a/server/src/admin-cli/admin-cli.ts
+++ b/server/src/admin-cli/admin-cli.ts
@@ -1,8 +1,8 @@
 import { App } from '../core';
 import { prompt } from 'inquirer';
 import { prompts } from './prompts';
-import { addVettedBeneficiaryCmd, upgradeUnvettedBeneficiaryCmd, verifyVettedBeneficiaryCmd } from './commands';
-import { ADD_VETTED_BENEFICIARY, UPGRADE_UNVETTED_BENEFICIARY, VERIFY_VETTED_BENEFICIARY } from './command-names';
+import { addVettedBeneficiaryCmd, sendBulkMessageCmd, upgradeUnvettedBeneficiaryCmd, verifyVettedBeneficiaryCmd } from './commands';
+import { ADD_VETTED_BENEFICIARY, SEND_BULK_MESSAGE, UPGRADE_UNVETTED_BENEFICIARY, VERIFY_VETTED_BENEFICIARY } from './command-names';
 
 export async function runAdminCLI(app: App) {
   async function cliLoop() {
@@ -19,6 +19,9 @@ export async function runAdminCLI(app: App) {
           break;
         case VERIFY_VETTED_BENEFICIARY:
           await verifyVettedBeneficiaryCmd(app);
+          break;
+        case SEND_BULK_MESSAGE:
+          await sendBulkMessageCmd(app);
           break;
       }
     }

--- a/server/src/admin-cli/command-names.ts
+++ b/server/src/admin-cli/command-names.ts
@@ -2,5 +2,6 @@ export const ADD_VETTED_BENEFICIARY = 'Add vetted beneficiary';
 export const UPGRADE_UNVETTED_BENEFICIARY  = 'Upgrade unvetted beneficiary';
 export const VERIFY_VETTED_BENEFICIARY = 'Verify vetted beneficiary';
 export const SEND_BULK_MESSAGE = 'Send bulk message';
+export const SHOW_USER_INFO = 'Show user information';
 export const SPECIFY_BENEFICIARY_BY_ID = 'ID';
 export const SPECIFY_BENEFICIARY_BY_PHONE = 'Phone';

--- a/server/src/admin-cli/command-names.ts
+++ b/server/src/admin-cli/command-names.ts
@@ -1,5 +1,6 @@
 export const ADD_VETTED_BENEFICIARY = 'Add vetted beneficiary';
 export const UPGRADE_UNVETTED_BENEFICIARY  = 'Upgrade unvetted beneficiary';
 export const VERIFY_VETTED_BENEFICIARY = 'Verify vetted beneficiary';
+export const SEND_BULK_MESSAGE = 'Send bulk message';
 export const SPECIFY_BENEFICIARY_BY_ID = 'ID';
 export const SPECIFY_BENEFICIARY_BY_PHONE = 'Phone';

--- a/server/src/admin-cli/commands.ts
+++ b/server/src/admin-cli/commands.ts
@@ -1,8 +1,8 @@
-import { App } from '../core';
-import { User } from '../core/user';
-import { prompts } from './prompts';
 import { prompt } from 'inquirer';
-import { UserAddVettedBeneficiaryArgs } from '../core/user/types';
+import { App } from '../core';
+import { isValid, validatePhone } from '../core/util';
+import { User, UserAddVettedBeneficiaryArgs } from '../core/user';
+import { prompts } from './prompts';
 import { SPECIFY_BENEFICIARY_BY_ID, SPECIFY_BENEFICIARY_BY_PHONE } from './command-names';
 
 export async function addVettedBeneficiaryCmd(app: App) {
@@ -137,7 +137,9 @@ export async function sendBulkMessageCmd(app: App) {
       return;
     }
 
-    const parsedRecipients = (<string>recipients).split(',').map(r => r.trim());
+    // trim and remove empty recipients
+    const parsedRecipients = (<string>recipients).split(',').map(r => r.trim()).filter(r => r);
+    console.log('Recipients', parsedRecipients);
     console.log('Sending messages, please wait...');
     const report = await app.bulkMessages.send(parsedRecipients, message);
 
@@ -152,6 +154,19 @@ export async function sendBulkMessageCmd(app: App) {
       console.log(`Error for recipient '${e.recipientGroup}', user '${e.user}': ${e.message}`);
     });
 
+  }
+  catch (e) {
+    console.error(e.message);
+  }
+}
+
+export async function showUserInfoCmd(app: App) {
+  try {
+    const { identifier } = await prompt(prompts.showUserInfo);
+    const user = isValid(identifier, validatePhone) ?
+      await app.users.getByPhone(identifier) : await app.users.getById(identifier);
+
+    console.log(user);
   }
   catch (e) {
     console.error(e.message);

--- a/server/src/admin-cli/commands.ts
+++ b/server/src/admin-cli/commands.ts
@@ -146,7 +146,7 @@ export async function sendBulkMessageCmd(app: App) {
 
     console.log('Messages sent');
     console.log('REPORT');
-    console.log(`Total recipients: ${report.numRecipients}`);
+    console.log(`Total sent: ${report.numRecipients}`);
     console.log();
     console.log('FAILURES');
     console.log(`Total failed: ${report.numFailed}`);

--- a/server/src/admin-cli/commands.ts
+++ b/server/src/admin-cli/commands.ts
@@ -123,6 +123,41 @@ export async function verifyVettedBeneficiaryCmd(app: App) {
   }
 }
 
+export async function sendBulkMessageCmd(app: App) {
+  try {
+    const { recipients, message } = await prompt(prompts.sendBulkMessage);
+    const preview = await app.bulkMessages.previewMessage(message);
+    console.log('Here is a preview of the message that will be sent:');
+    console.log(preview);
+    prompts.confirmCommand[0].message = `Are you sure you want proceed sending the message?`;
+    const { confirmation } = await prompt(prompts.confirmCommand);
+
+    if (!confirmation) {
+      console.log('Command aborted!');
+      return;
+    }
+
+    const parsedRecipients = (<string>recipients).split(',').map(r => r.trim());
+    console.log('Sending messages, please wait...');
+    const report = await app.bulkMessages.send(parsedRecipients, message);
+
+    console.log('Messages sent');
+    console.log(`Total recipients: ${report.numRecipients}`);
+    console.log(`Total failed: ${report.numFailed}`);
+    if (report.errors.length) {
+      
+    }
+
+    report.errors.forEach(e => {
+      console.log(`Error for recipient '${e.recipientGroup}', user '${e.user}': ${e.message}`);
+    });
+
+  }
+  catch (e) {
+    console.error(e.message);
+  }
+}
+
 async function verifyVettedBeneficiaryByProperty(property: string, value: string, app: App) {
   let verifiedVettedBeneficiary;
   try {

--- a/server/src/admin-cli/commands.ts
+++ b/server/src/admin-cli/commands.ts
@@ -144,15 +144,16 @@ export async function sendBulkMessageCmd(app: App) {
     const report = await app.bulkMessages.send(parsedRecipients, message);
 
     console.log('Messages sent');
+    console.log('REPORT');
     console.log(`Total recipients: ${report.numRecipients}`);
+    console.log(report.recipients.map(r => `${r.name} (${r.user})`).join(', '));
+    console.log();
+    console.log('FAILURES');
     console.log(`Total failed: ${report.numFailed}`);
-    if (report.errors.length) {
-      
-    }
-
     report.errors.forEach(e => {
       console.log(`Error for recipient '${e.recipientGroup}', user '${e.user}': ${e.message}`);
     });
+    console.log();
 
   }
   catch (e) {

--- a/server/src/admin-cli/commands.ts
+++ b/server/src/admin-cli/commands.ts
@@ -128,6 +128,7 @@ export async function sendBulkMessageCmd(app: App) {
     const { recipients, message } = await prompt(prompts.sendBulkMessage);
     const preview = await app.bulkMessages.previewMessage(message);
     console.log('Here is a preview of the message that will be sent:');
+    console.log();
     console.log(preview);
     prompts.confirmCommand[0].message = `Are you sure you want proceed sending the message?`;
     const { confirmation } = await prompt(prompts.confirmCommand);
@@ -146,12 +147,11 @@ export async function sendBulkMessageCmd(app: App) {
     console.log('Messages sent');
     console.log('REPORT');
     console.log(`Total recipients: ${report.numRecipients}`);
-    console.log(report.recipients.map(r => `${r.name} (${r.user})`).join(', '));
     console.log();
     console.log('FAILURES');
     console.log(`Total failed: ${report.numFailed}`);
     report.errors.forEach(e => {
-      console.log(`Error for recipient '${e.recipientGroup}', user '${e.user}': ${e.message}`);
+      console.log(`- Error for recipient '${e.recipientGroup}', user '${e.user}': ${e.message}`);
     });
     console.log();
 

--- a/server/src/admin-cli/prompts.ts
+++ b/server/src/admin-cli/prompts.ts
@@ -1,6 +1,6 @@
 import {
   ADD_VETTED_BENEFICIARY, UPGRADE_UNVETTED_BENEFICIARY, VERIFY_VETTED_BENEFICIARY, SEND_BULK_MESSAGE,
-  SPECIFY_BENEFICIARY_BY_ID, SPECIFY_BENEFICIARY_BY_PHONE
+  SPECIFY_BENEFICIARY_BY_ID, SPECIFY_BENEFICIARY_BY_PHONE, SHOW_USER_INFO
 } from './command-names';
 
 export const prompts = {
@@ -9,7 +9,7 @@ export const prompts = {
       type: 'list',
       message: 'Select a command to continue:',
       name: 'command',
-      choices: [ADD_VETTED_BENEFICIARY, UPGRADE_UNVETTED_BENEFICIARY, VERIFY_VETTED_BENEFICIARY, SEND_BULK_MESSAGE]
+      choices: [SHOW_USER_INFO, ADD_VETTED_BENEFICIARY, UPGRADE_UNVETTED_BENEFICIARY, VERIFY_VETTED_BENEFICIARY, SEND_BULK_MESSAGE]
     }
   ],
   addVettedBeneficiary: [
@@ -69,6 +69,13 @@ export const prompts = {
       type: 'input',
       message: 'Enter message to send. You can include placeholders like {firstName}, {donateLink} or {baseUrl}',
       name: 'message'
+    }
+  ],
+  showUserInfo: [
+    {
+      type: 'input',
+      message: 'Enter user\'s id or phone number',
+      name: 'identifier'
     }
   ],
   confirmCommand: [

--- a/server/src/admin-cli/prompts.ts
+++ b/server/src/admin-cli/prompts.ts
@@ -1,5 +1,5 @@
 import {
-  ADD_VETTED_BENEFICIARY, UPGRADE_UNVETTED_BENEFICIARY, VERIFY_VETTED_BENEFICIARY, 
+  ADD_VETTED_BENEFICIARY, UPGRADE_UNVETTED_BENEFICIARY, VERIFY_VETTED_BENEFICIARY, SEND_BULK_MESSAGE,
   SPECIFY_BENEFICIARY_BY_ID, SPECIFY_BENEFICIARY_BY_PHONE
 } from './command-names';
 
@@ -9,7 +9,7 @@ export const prompts = {
       type: 'list',
       message: 'Select a command to continue:',
       name: 'command',
-      choices: [ADD_VETTED_BENEFICIARY, UPGRADE_UNVETTED_BENEFICIARY, VERIFY_VETTED_BENEFICIARY]
+      choices: [ADD_VETTED_BENEFICIARY, UPGRADE_UNVETTED_BENEFICIARY, VERIFY_VETTED_BENEFICIARY, SEND_BULK_MESSAGE]
     }
   ],
   addVettedBeneficiary: [
@@ -57,6 +57,18 @@ export const prompts = {
       type: 'input',
       name: 'phone',
       message: 'Phone:'
+    }
+  ],
+  sendBulkMessage: [
+    {
+      type: 'input',
+      message: 'Enter recipients, separated by a comma. A recipient can \'donors\', \'beneficiaries\' or a phone number',
+      name: 'recipients'
+    },
+    {
+      type: 'input',
+      message: 'Enter message to send. You can include placeholders like {firstName}, {donateLink} or {baseUrl}',
+      name: 'message'
     }
   ],
   confirmCommand: [

--- a/server/src/admin-cli/prompts.ts
+++ b/server/src/admin-cli/prompts.ts
@@ -62,19 +62,19 @@ export const prompts = {
   sendBulkMessage: [
     {
       type: 'input',
-      message: 'Enter recipients, separated by a comma. A recipient can \'donors\', \'beneficiaries\' or a phone number',
+      message: 'Enter recipients, separated by a comma. A recipient can \'donors\', \'beneficiaries\' or a phone number:\n',
       name: 'recipients'
     },
     {
       type: 'input',
-      message: 'Enter message to send. You can include placeholders like {firstName}, {donateLink} or {baseUrl}',
+      message: 'Enter message to send. You can include placeholders like {firstName}, {donateLink} or {baseUrl}:\n',
       name: 'message'
     }
   ],
   showUserInfo: [
     {
       type: 'input',
-      message: 'Enter user\'s id or phone number',
+      message: 'Enter user\'s id or phone number:',
       name: 'identifier'
     }
   ],

--- a/server/src/core/app.ts
+++ b/server/src/core/app.ts
@@ -4,6 +4,7 @@ import { InvitationService } from './invitation';
 import { DonationDistributionService } from './distribution';
 import { StatsService } from './stat';
 import { DistributionReportService } from './distribution-report';
+import { BulkMessageService } from './bulk-messaging';
 
 export interface App {
   users: UserService;
@@ -12,6 +13,7 @@ export interface App {
   donationDistributions: DonationDistributionService;
   stats: StatsService;
   distributionReports: DistributionReportService;
+  bulkMessages: BulkMessageService;
 };
 
 export interface AppConfig {

--- a/server/src/core/batch-job-queue/batch-job-queue.ts
+++ b/server/src/core/batch-job-queue/batch-job-queue.ts
@@ -30,6 +30,7 @@ export interface BatchJobQueueHandler<T> {
 export class BatchJobQueue<T> extends EventEmitter {
   private eof = false;
   private busy = false;
+  private isDone = false;
   private buffer: T[];
   private batchSize: number;
   private handler: BatchJobQueueHandler<T>;
@@ -76,7 +77,7 @@ export class BatchJobQueue<T> extends EventEmitter {
    * processing all the jobs 
    */
   run (): Promise<void> {
-    if (this.eof) {
+    if (this.isDone) {
       return Promise.resolve();
     }
 
@@ -100,6 +101,7 @@ export class BatchJobQueue<T> extends EventEmitter {
       await Promise.all(batch.map(this.handler));
       this.busy = false;
       if (this.isEmpty && this.eof) {
+        this.isDone = true;
         this.emit('done');
         return;
       }

--- a/server/src/core/batch-job-queue/batch-job-queue.ts
+++ b/server/src/core/batch-job-queue/batch-job-queue.ts
@@ -71,6 +71,20 @@ export class BatchJobQueue<T> extends EventEmitter {
     }
   }
 
+  /**
+   * Returns a promise that is resolved when the queue has completed
+   * processing all the jobs 
+   */
+  run (): Promise<void> {
+    if (this.eof) {
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve) => {
+      this.on('done', () => resolve());
+    });
+  }
+
   private takeNextBatch () {
     const batch = this.buffer.splice(0, this.batchSize);
     return batch;

--- a/server/src/core/batch-job-queue/tests/batch-job-queue.test.ts
+++ b/server/src/core/batch-job-queue/tests/batch-job-queue.test.ts
@@ -25,6 +25,23 @@ describe('BatchJobQueue', () => {
     queue.signalEof();
   });
 
+  test('should return promise that is resolved after completion when run is called', async () => {
+    queue.push(1);
+    queue.push(2);
+    queue.push(3);
+    queue.push(4);
+    queue.push(5);
+    queue.push(6);
+    queue.signalEof();
+    await queue.run();
+    expect(handler).toHaveBeenCalledWith(1);
+    expect(handler).toHaveBeenCalledWith(2);
+    expect(handler).toHaveBeenCalledWith(3);
+    expect(handler).toHaveBeenCalledWith(4);
+    expect(handler).toHaveBeenCalledWith(5);
+    expect(handler).toHaveBeenCalledWith(6);
+  });
+
   test('should not run new jobs until it has enough tasks in queue (as determined by batchSize)', (done) => {
     queue.push(1);
     process.nextTick(() => {

--- a/server/src/core/bootstrap.ts
+++ b/server/src/core/bootstrap.ts
@@ -13,6 +13,7 @@ import { UserNotifications } from './user-notification';
 import { Statistics } from './stat';
 import { DistributionReports } from './distribution-report';
 import { Links, BitlyLinkShortener } from './link-generator';
+import { BulkMessages, DefaultMessageContextFactory } from './bulk-messaging';
 
 export async function bootstrap(config: AppConfig): Promise<App> {
   const client = await getDbConnection(config.dbUri);
@@ -93,6 +94,17 @@ export async function bootstrap(config: AppConfig): Promise<App> {
     links
   });
 
+  const messageContextFactory = new DefaultMessageContextFactory({
+    baseUrl: config.webappBaseUrl,
+    linkGenerator: links
+  });
+
+  const bulkMessages = new BulkMessages({
+    users,
+    smsProvider,
+    contextFactory: messageContextFactory
+  });
+
   await users.createIndexes();
   await transactions.createIndexes();
   await invitations.createIndexes();
@@ -103,7 +115,8 @@ export async function bootstrap(config: AppConfig): Promise<App> {
     invitations,
     donationDistributions,
     stats,
-    distributionReports
+    distributionReports,
+    bulkMessages
   };
 }
 

--- a/server/src/core/bulk-messaging/bulk-message-service.ts
+++ b/server/src/core/bulk-messaging/bulk-message-service.ts
@@ -121,7 +121,7 @@ export class BulkMessages implements BulkMessageService {
     catch (e) {
       report.errors.push({
         message: e.message,
-        user: recipient._id,
+        user: recipient._id
       });
 
       report.numFailed += 1;

--- a/server/src/core/bulk-messaging/bulk-message-service.ts
+++ b/server/src/core/bulk-messaging/bulk-message-service.ts
@@ -1,48 +1,130 @@
 import { BatchJobQueue } from '../batch-job-queue';
-import { User } from '../user';
+import { createAppError, createValidationError } from '../error';
+import { User, UserService } from '../user';
+import { DefaultRecipientResolver } from './recipient-resolver';
 import { DefaultMessageTemplateResolver } from './template-resolver';
-import { BulkMessageService, MessageContextFactory, MessageSender, MessageTemplateResolver, RecipientResolver } from './types';
+import { BulkMessageReport, BulkMessageService, MessageContextFactory, BulkMessagesTransport, MessageTemplateResolver, RecipientResolver } from './types';
 
 export interface BulkMessagesArgs {
-  recipientResolver: RecipientResolver;
   contextFactory: MessageContextFactory;
   templateResolver?: MessageTemplateResolver;
-  sender: MessageSender;
+  transport: BulkMessagesTransport;
+  recipientResolver?: RecipientResolver;
+  users?: UserService
 }
 
 export class BulkMessages implements BulkMessageService {
   recipientResolver: RecipientResolver;
   contextFactory: MessageContextFactory;
   templateResolver: MessageTemplateResolver;
-  sender: MessageSender;
+  transport: BulkMessagesTransport;
 
   constructor(args: BulkMessagesArgs) {
-    this.recipientResolver = args.recipientResolver;
+    if (!args.recipientResolver && !args.users) {
+      throw createAppError('Bulk message args must provide either recipientsResolver or users')
+    }
+
     this.contextFactory = args.contextFactory;
     this.templateResolver = args.templateResolver || new DefaultMessageTemplateResolver();
-    this.sender = args.sender;
+    this.recipientResolver = args.recipientResolver || new DefaultRecipientResolver({ users: args.users });
+    this.transport = args.transport;
   }
 
-  async send(recipientGroups: string[], messageTemplate: string): Promise<void> {
-    // we assume we'll have a few recipient groups, but a single group might
-    // resolve into many recipients. So we don't use a batch queue here
-    const tasks = recipientGroups.map(group => this.sendToRecipientGroup(group, messageTemplate));
+  async send(recipientGroups: string[], messageTemplate: string): Promise<BulkMessageReport> {
+    // validate recipients
+    const invalidGroups = recipientGroups.filter(group => !this.recipientResolver.canResolve(group));
+    if (invalidGroups.length) {
+      throw createValidationError(`Invalid recipients: ${invalidGroups.map(g => `'${g}'`).join(', ')}`);
+    }
+
+    const report: BulkMessageReport = {
+      errors: [],
+      numFailed: 0,
+      numRecipients: 0
+    };
+
+    const allRecipients = await this.getRecipients(recipientGroups, report);
+    await this.sendToRecipients(allRecipients, messageTemplate, report);
+
+    return report;
+  }
+
+  async previewMessage(messageTemplate: string): Promise<string> {
+    // create a dummy user and generate a preview message
+    // based on that user
+
+    const user: User = {
+      _id: 'dummy_user',
+      phone: '254700000000',
+      name: 'John Doe',
+      donors: [],
+      roles: ['donor'],
+      addedBy: '',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    };
+
+    const message = await this.createMessageForUser(user, messageTemplate);
+    return message;
+  }
+
+  private async getRecipients(recipientGroups: string[], report: BulkMessageReport): Promise<User[]> {
+    const allRecipients: User[] = [];
+    const recipientIds: Set<string> = new Set<string>();
+    const tasks = recipientGroups.map(group => this.addRecipientsFromGroup(group, allRecipients, recipientIds, report));
     await Promise.all(tasks);
+    return Array.from(allRecipients);
   }
 
-  private async sendToRecipientGroup(recipientGroup: string, messageTemplate: string): Promise<void> {
-    const recipients = await this.recipientResolver.resolve(recipientGroup);
+  private async addRecipientsFromGroup(group: string, allRecipients: User[], recipientIds: Set<string>, report: BulkMessageReport) {
+    try {
+      const recipients = await this.recipientResolver.resolve(group);
+      recipients.forEach(r => {
+        if (!recipientIds.has(r._id)) {
+          allRecipients.push(r);
+          recipientIds.add(r._id);
+        }
+      });
+    }
+    catch (e) {
+      report.errors.push({
+        recipientGroup: group,
+        user: null,
+        message: e.message
+      });
 
-    var queue = new BatchJobQueue<User>(recipient => this.sendToRecipient(recipient, messageTemplate));
+      report.numFailed += 1;
+    }
+  }
+
+  private async sendToRecipients(recipients: User[], messageTemplate: string, report: BulkMessageReport): Promise<void> {
+    var queue = new BatchJobQueue<User>(recipient => this.sendToRecipient(recipient, messageTemplate, report));
 
     recipients.forEach(recipient => queue.push(recipient));
-    return queue.run();
+    queue.signalEof();
+    await queue.run();
   }
 
-  private async sendToRecipient(recipient: User, template: string): Promise<void> {
-    const context = await this.contextFactory.createContextFromUser(recipient);
+  private async sendToRecipient(recipient: User, template: string, report: BulkMessageReport): Promise<void> {
+    try {
+      const message = await this.createMessageForUser(recipient, template);
+      await this.transport.sendMessage(recipient, message);
+      report.numRecipients += 1;
+    }
+    catch (e) {
+      report.errors.push({
+        message: e.message,
+        user: recipient._id,
+      });
+
+      report.numFailed += 1;
+    }
+  }
+
+  private async createMessageForUser(user: User, template: string): Promise<string> {
+    const context = await this.contextFactory.createContextFromUser(user);
     const message = await this.templateResolver.resolve(context, template);
-    return this.sender.sendMessage(recipient, message);
+    return message;
   }
 
 }

--- a/server/src/core/bulk-messaging/bulk-message-service.ts
+++ b/server/src/core/bulk-messaging/bulk-message-service.ts
@@ -1,0 +1,33 @@
+import { BatchJobQueue } from '../batch-job-queue';
+import { User } from '../user';
+import { BulkMessageService, MessageContextFactory, MessageSender, MessageTemplateResolver, RecipientResolver } from './types';
+
+export class BulkMessages implements BulkMessageService {
+  recipientResolver: RecipientResolver;
+  contextFactory: MessageContextFactory;
+  templateResolver: MessageTemplateResolver;
+  sender: MessageSender;
+
+  async send(recipientGroups: string[], messageTemplate: string): Promise<void> {
+    // we assume we'll have a few recipient groups, but a single group might
+    // resolve into many recipients. So we don't use a batch queue here
+    const tasks = recipientGroups.map(group => this.sendToRecipientGroup(group, messageTemplate));
+    await Promise.all(tasks);
+  }
+
+  private async sendToRecipientGroup(recipientGroup: string, messageTemplate: string): Promise<void> {
+    const recipients = await this.recipientResolver.resolve(recipientGroup);
+
+    var queue = new BatchJobQueue<User>(recipient => this.sendToRecipient(recipient, messageTemplate));
+
+    recipients.forEach(recipient => queue.push(recipient));
+    return queue.run();
+  }
+
+  private async sendToRecipient(recipient: User, template: string): Promise<void> {
+    const context = await this.contextFactory.createContextFromUser(recipient);
+    const message = await this.templateResolver.resolve(context, template);
+    return this.sender.sendMessage(recipient, message);
+  }
+
+}

--- a/server/src/core/bulk-messaging/bulk-message-service.ts
+++ b/server/src/core/bulk-messaging/bulk-message-service.ts
@@ -1,11 +1,12 @@
 import { BatchJobQueue } from '../batch-job-queue';
 import { User } from '../user';
+import { DefaultMessageTemplateResolver } from './template-resolver';
 import { BulkMessageService, MessageContextFactory, MessageSender, MessageTemplateResolver, RecipientResolver } from './types';
 
 export interface BulkMessagesArgs {
   recipientResolver: RecipientResolver;
   contextFactory: MessageContextFactory;
-  templateResolver: MessageTemplateResolver;
+  templateResolver?: MessageTemplateResolver;
   sender: MessageSender;
 }
 
@@ -18,7 +19,7 @@ export class BulkMessages implements BulkMessageService {
   constructor(args: BulkMessagesArgs) {
     this.recipientResolver = args.recipientResolver;
     this.contextFactory = args.contextFactory;
-    this.templateResolver = args.templateResolver;
+    this.templateResolver = args.templateResolver || new DefaultMessageTemplateResolver();
     this.sender = args.sender;
   }
 

--- a/server/src/core/bulk-messaging/bulk-message-service.ts
+++ b/server/src/core/bulk-messaging/bulk-message-service.ts
@@ -47,7 +47,8 @@ export class BulkMessages implements BulkMessageService {
     const report: BulkMessageReport = {
       errors: [],
       numFailed: 0,
-      numRecipients: 0
+      numRecipients: 0,
+      recipients: []
     };
 
     const allRecipients = await this.getRecipients(recipientGroups, report);
@@ -97,6 +98,7 @@ export class BulkMessages implements BulkMessageService {
       report.errors.push({
         recipientGroup: group,
         user: null,
+        name: null,
         message: e.message
       });
 
@@ -117,11 +119,16 @@ export class BulkMessages implements BulkMessageService {
       const message = await this.createMessageForUser(recipient, template);
       await this.transport.sendMessage(recipient, message);
       report.numRecipients += 1;
+      report.recipients.push({
+        user: recipient._id,
+        name: recipient.name
+      });
     }
     catch (e) {
       report.errors.push({
         message: e.message,
-        user: recipient._id
+        user: recipient._id,
+        name: recipient.name
       });
 
       report.numFailed += 1;

--- a/server/src/core/bulk-messaging/bulk-message-service.ts
+++ b/server/src/core/bulk-messaging/bulk-message-service.ts
@@ -2,11 +2,25 @@ import { BatchJobQueue } from '../batch-job-queue';
 import { User } from '../user';
 import { BulkMessageService, MessageContextFactory, MessageSender, MessageTemplateResolver, RecipientResolver } from './types';
 
+export interface BulkMessagesArgs {
+  recipientResolver: RecipientResolver;
+  contextFactory: MessageContextFactory;
+  templateResolver: MessageTemplateResolver;
+  sender: MessageSender;
+}
+
 export class BulkMessages implements BulkMessageService {
   recipientResolver: RecipientResolver;
   contextFactory: MessageContextFactory;
   templateResolver: MessageTemplateResolver;
   sender: MessageSender;
+
+  constructor(args: BulkMessagesArgs) {
+    this.recipientResolver = args.recipientResolver;
+    this.contextFactory = args.contextFactory;
+    this.templateResolver = args.templateResolver;
+    this.sender = args.sender;
+  }
 
   async send(recipientGroups: string[], messageTemplate: string): Promise<void> {
     // we assume we'll have a few recipient groups, but a single group might

--- a/server/src/core/bulk-messaging/context-factory.ts
+++ b/server/src/core/bulk-messaging/context-factory.ts
@@ -1,0 +1,29 @@
+import { LinkGeneratorService } from '../link-generator';
+import { User } from '../user';
+import { extractFirstName } from '../util';
+import { MessageContextFactory, MessageTemplateContext } from './types';
+
+const DEFAULT_DONATION = 2000;
+
+export interface DefaultMessageContextFactoryArgs {
+  linkGenerator: LinkGeneratorService;
+  baseUrl: string;
+}
+
+export class DefaultMessageContextFactory implements MessageContextFactory {
+  linkGenerator: LinkGeneratorService;
+  baseUrl: string;
+
+  constructor(args: DefaultMessageContextFactoryArgs) {
+    this.linkGenerator = args.linkGenerator;
+    this.baseUrl = args.baseUrl;
+  }
+
+  async createContextFromUser(user: User): Promise<MessageTemplateContext> {
+    return {
+      firstName: extractFirstName(user.name),
+      baseUrl: this.baseUrl,
+      donateLink: await this.linkGenerator.getUserDonateLink(user, DEFAULT_DONATION)
+    };
+  }
+}

--- a/server/src/core/bulk-messaging/index.ts
+++ b/server/src/core/bulk-messaging/index.ts
@@ -1,0 +1,6 @@
+export * from './types';
+export { BulkMessages, BulkMessagesArgs } from './bulk-message-service';
+export { DefaultBulkMessageTransport, DefaultBulkMessageSenderArgs } from './message-transport';
+export { DefaultMessageTemplateResolver } from './template-resolver'
+export { DefaultRecipientResolver, DefaultRecipientResolverArgs, CombinedRecipientResolver } from './recipient-resolver';
+export { DefaultMessageContextFactory, DefaultMessageContextFactoryArgs } from './context-factory';

--- a/server/src/core/bulk-messaging/message-transport.ts
+++ b/server/src/core/bulk-messaging/message-transport.ts
@@ -1,0 +1,20 @@
+import { SmsProvider } from '../sms';
+import { User } from '../user';
+import { MessageSender as BulkMessageTransport } from './types';
+
+export interface DefaultBulkMessageSenderArgs {
+  smsProvider: SmsProvider;
+}
+
+export class DefaultBulkMessageTransport implements BulkMessageTransport {
+  smsProvider: SmsProvider;
+
+  constructor(args: DefaultBulkMessageSenderArgs) {
+    this.smsProvider = args.smsProvider;
+  }
+
+  async sendMessage(recipient: User, message: string): Promise<void> {
+    await this.smsProvider.sendSms(recipient.phone, message);
+  }
+  
+}

--- a/server/src/core/bulk-messaging/message-transport.ts
+++ b/server/src/core/bulk-messaging/message-transport.ts
@@ -1,6 +1,6 @@
 import { SmsProvider } from '../sms';
 import { User } from '../user';
-import { MessageSender as BulkMessageTransport } from './types';
+import { BulkMessagesTransport as BulkMessageTransport } from './types';
 
 export interface DefaultBulkMessageSenderArgs {
   smsProvider: SmsProvider;

--- a/server/src/core/bulk-messaging/recipient-resolver.ts
+++ b/server/src/core/bulk-messaging/recipient-resolver.ts
@@ -101,7 +101,6 @@ export class PhoneRecipientResolver implements RecipientResolver {
 
   async resolve(recipient: string): Promise<User[]> {
     const user = await this.users.getByPhone(recipient);
-    // TODO throw error if user does not exist
     return [user];
   }
 

--- a/server/src/core/bulk-messaging/recipient-resolver.ts
+++ b/server/src/core/bulk-messaging/recipient-resolver.ts
@@ -1,6 +1,6 @@
 import { createAppError } from '../error';
 import { User, UserService } from '../user';
-import { validatePhone } from '../util';
+import { isValid, validatePhone } from '../util';
 import { RecipientResolver } from './types';
 
 const DONORS_RECIPIENT_GROUP = 'donors';
@@ -90,13 +90,7 @@ export class PhoneRecipientResolver implements RecipientResolver {
   }
   
   canResolve(recipient: string): boolean {
-    try {
-      validatePhone(recipient);
-      return true;
-    }
-    catch (e) {
-      return false;
-    }
+    return isValid(recipient, validatePhone);
   }
 
   async resolve(recipient: string): Promise<User[]> {

--- a/server/src/core/bulk-messaging/recipient-resolver.ts
+++ b/server/src/core/bulk-messaging/recipient-resolver.ts
@@ -1,0 +1,89 @@
+import { User, UserService } from '../user';
+import { validatePhone } from '../util';
+import { RecipientResolver } from './types';
+
+const DONORS_RECIPIENT_GROUP = 'donors';
+const BENEFICIARIES_RECIPIENT_GROUP = 'beneficiaries';
+
+export interface DefaultRecipientResolverArgs {
+  users: UserService;
+}
+
+export class DefaultRecipientResolver implements RecipientResolver {
+  resolvers: RecipientResolver[];
+
+  constructor(args: DefaultRecipientResolverArgs) {
+    this.resolvers = [
+      new DonorGroupRecipientResolver(args.users),
+      new BeneficiaryGroupRecipientResolver(args.users),
+      new PhoneRecipientResolver(args.users)
+    ]
+  }
+
+  canResolve(recipient: string): boolean {
+    return this.resolvers.some(resolver => resolver.canResolve(recipient));
+  }
+
+  resolve(recipient: string): Promise<User[]> {
+    const resolver = this.resolvers.find(candidate => candidate.canResolve(recipient));
+    // TODO: throw error if resolver not found
+    return resolver.resolve(recipient);
+  }
+
+}
+
+export class DonorGroupRecipientResolver implements RecipientResolver {
+  users: UserService;
+
+  constructor(users: UserService) {
+    this.users = users;
+  }
+
+  canResolve(recipient: string): boolean {
+    return recipient === DONORS_RECIPIENT_GROUP;
+  }
+  resolve(recipient: string): Promise<User[]> {
+    return this.users.getAllDonors();
+  }
+}
+
+export class BeneficiaryGroupRecipientResolver implements RecipientResolver {
+  users: UserService;
+
+  constructor(users: UserService) {
+    this.users = users;
+  }
+
+  canResolve(recipient: string): boolean {
+    return recipient === BENEFICIARIES_RECIPIENT_GROUP;
+  }
+
+  resolve(recipient: string): Promise<User[]> {
+    return this.users.getAllBeneficiaries();
+  }
+}
+
+export class PhoneRecipientResolver implements RecipientResolver {
+  users: UserService;
+
+  constructor(users: UserService) {
+    this.users = users;
+  }
+  
+  canResolve(recipient: string): boolean {
+    try {
+      validatePhone(recipient);
+      return true;
+    }
+    catch (e) {
+      return false;
+    }
+  }
+
+  async resolve(recipient: string): Promise<User[]> {
+    const user = await this.users.getByPhone(recipient);
+    // TODO throw error if user does not exist
+    return [user];
+  }
+
+}

--- a/server/src/core/bulk-messaging/template-resolver.ts
+++ b/server/src/core/bulk-messaging/template-resolver.ts
@@ -1,0 +1,14 @@
+import { MessageTemplateContext, MessageTemplateResolver } from './types';
+
+const regexForPlaceholder = (placeholder: string) => new RegExp(`{${placeholder}}`, 'gi');
+
+export class DefaultMessageTemplateResolver implements MessageTemplateResolver {
+  resolve(context: MessageTemplateContext, messageTemplate: string): Promise<string> {
+    const vars = Object.keys(context);
+    const message = vars.reduce((messageSoFar, placeholder) =>
+      messageSoFar.replace(regexForPlaceholder(placeholder), context[placeholder]),
+      messageTemplate)
+    
+    return Promise.resolve(message);
+  }
+}

--- a/server/src/core/bulk-messaging/tests/bulk-message-service.test.ts
+++ b/server/src/core/bulk-messaging/tests/bulk-message-service.test.ts
@@ -74,6 +74,12 @@ describe('BulkMessages', () => {
       
       expect(report.errors.length).toBe(0);
       expect(report.numRecipients).toEqual(4);
+      expect(report.recipients).toEqual([
+        { user: 'd1', name: 'Fizz Buzz' },
+        { user: 'd2', name: 'What What' },
+        { user: 'u1', name: 'Xy Zw' },
+        { user: 'u2', name: 'Op Fa' }
+      ])
       expect(report.numFailed).toEqual(0);
       expect(service.transport.sendMessage).toHaveBeenCalledTimes(4);
       const expectedArgs = [
@@ -106,7 +112,8 @@ describe('BulkMessages', () => {
         {
           message: 'User not found',
           recipientGroup: '254700111444',
-          user: null
+          user: null,
+          name: null
         }
       ]);
     });

--- a/server/src/core/bulk-messaging/tests/bulk-message-service.test.ts
+++ b/server/src/core/bulk-messaging/tests/bulk-message-service.test.ts
@@ -28,9 +28,6 @@ describe('BulkMessages', () => {
   let service: BulkMessages;
   let users: UserService;
   let contextFactory: TestContextFactory;
-  let transport: TestMessageTransport;
-
-  
 
   beforeEach(() => {
     users = {
@@ -60,7 +57,6 @@ describe('BulkMessages', () => {
     };
 
     contextFactory = new TestContextFactory();
-    transport = new TestMessageTransport();
 
     service = new BulkMessages({
       users,
@@ -113,6 +109,14 @@ describe('BulkMessages', () => {
           user: null
         }
       ]);
+    });
+  });
+
+  describe('previewMessage', () => {
+    test('should show return resolved template message based on a dummy user', async () => {
+      const template = 'Hi {firstName}, Click here to donate {donateLink}';
+      const preview = await service.previewMessage(template);
+      expect(preview).toBe('Hi John, Click here to donate https://donate?u=dummy_user');
     });
   });
 });

--- a/server/src/core/bulk-messaging/tests/bulk-message-service.test.ts
+++ b/server/src/core/bulk-messaging/tests/bulk-message-service.test.ts
@@ -1,0 +1,118 @@
+import { extractFirstName } from '../../util';
+import { User, UserService } from '../../user';
+import { BulkMessages } from '../bulk-message-service';
+import { BulkMessagesTransport, MessageContextFactory, MessageTemplateContext } from '../types';
+import { createAppError } from '../../error';
+
+class TestContextFactory implements MessageContextFactory {
+  createContextFromUser(user: User): Promise<MessageTemplateContext> {
+    return Promise.resolve({
+      firstName: extractFirstName(user.name),
+      baseUrl: 'https://example.com',
+      donateLink: `https://donate?u=${user._id}`
+    });
+  }
+}
+
+class TestMessageTransport implements BulkMessagesTransport {
+  sentMessages: Array<{recipient: User, message: string}> = [];
+
+  sendMessage(recipient: User, message: string): Promise<void> {
+    this.sentMessages.push({ message, recipient });
+    return Promise.resolve();
+  }
+  
+}
+
+describe('BulkMessages', () => {
+  let service: BulkMessages;
+  let users: UserService;
+  let contextFactory: TestContextFactory;
+  let transport: TestMessageTransport;
+
+  
+
+  beforeEach(() => {
+    users = {
+      // @ts-ignore  
+      getAllBeneficiaries: () => Promise.resolve([
+        { _id: 'b1', name: 'John Doe' },
+        { _id: 'b2', name: 'Foo Bar' }
+      ]),
+      // @ts-ignore
+      getAllDonors: () => Promise.resolve([
+        { _id: 'd1', name: 'Fizz Buzz' },
+        { _id: 'd2', name: 'What What'},
+        { _id: 'u1', name: 'Xy Zw' }
+      ]),
+      // @ts-ignore
+      getByPhone: (phone) => {
+        if (phone === '254700111222') {
+          return Promise.resolve({ _id: 'u1', name: 'Xy Zw' });
+        }
+
+        if (phone === '254700111333') {
+          return Promise.resolve({ _id: 'u2', name: 'Op Fa' });
+        }
+
+        throw createAppError('User not found');
+      }
+    };
+
+    contextFactory = new TestContextFactory();
+    transport = new TestMessageTransport();
+
+    service = new BulkMessages({
+      users,
+      contextFactory,
+      transport: {
+        sendMessage: jest.fn().mockImplementation(() => Promise.resolve())
+      }
+    });
+  });
+
+  describe('send', () => {
+    test('should send message to all resolved unique recipients and return report', async () => {
+      const template = 'Hi {firstName}, Click here to donate {donateLink}';
+      const report = await service.send(['donors', '254700111222', '254700111333'], template);
+      
+      expect(report.errors.length).toBe(0);
+      expect(report.numRecipients).toEqual(4);
+      expect(report.numFailed).toEqual(0);
+      expect(service.transport.sendMessage).toHaveBeenCalledTimes(4);
+      const expectedArgs = [
+        [{ _id: 'd1', name: 'Fizz Buzz' }, 'Hi Fizz, Click here to donate https://donate?u=d1'],
+        [{ _id: 'd2', name: 'What What'}, 'Hi What, Click here to donate https://donate?u=d2'],
+        [{ _id: 'u1', name: 'Xy Zw' }, 'Hi Xy, Click here to donate https://donate?u=u1'],
+        [{ _id: 'u2', name: 'Op Fa' }, 'Hi Op, Click here to donate https://donate?u=u2']
+      ];
+
+      expectedArgs.forEach(args => expect(service.transport.sendMessage).toHaveBeenCalledWith(args[0], args[1]));
+    });
+
+    test('should throw error if recipient groups are invalid', async () => {
+      const template = 'Hi {firstName}, Click here to donate {donateLink}';
+      try {
+        await service.send(['donors', 'benficiaris', '0700111333'], template);
+      }
+      catch (e) {
+        expect(e.message).toMatch(/invalid recipients: 'benficiaris', '0700111333'/i)
+      }
+    });
+
+    test('should include failures in report', async () => {
+      const template = 'Hi {firstName}, Click here to donate {donateLink}';
+      const report = await service.send(['donors', '254700111222', '254700111444'], template);
+      
+      expect(report.numRecipients).toEqual(3);
+      expect(report.numFailed).toEqual(1);
+      expect(report.errors).toEqual([
+        {
+          message: 'User not found',
+          recipientGroup: '254700111444',
+          user: null
+        }
+      ]);
+    });
+  });
+});

--- a/server/src/core/bulk-messaging/tests/context-factory.test.ts
+++ b/server/src/core/bulk-messaging/tests/context-factory.test.ts
@@ -1,0 +1,23 @@
+import { User } from '../../user';
+import { LinkGeneratorService } from '../../link-generator';
+import { DefaultMessageContextFactory } from '../context-factory';
+
+
+describe('DefaultBulkMessageContextFactory', () => {
+  describe('createFromUser', () => {
+    test('should create message context with generated donateLink and user first name', async () => {
+      const linkGenerator: LinkGeneratorService = {
+        getUserDonateLink: (user, amount) => Promise.resolve(`https://donate?p=${user.phone}&a=${amount}`),
+        getDonateLink: () => Promise.resolve('')
+      };
+      const factory = new DefaultMessageContextFactory({ baseUrl: 'https://example.com', linkGenerator })
+      const context = await factory.createContextFromUser(<User>{ name: 'John Doe', phone: '254777111222' })
+
+      expect(context).toEqual({
+        firstName: 'John',
+        baseUrl: 'https://example.com',
+        donateLink: 'https://donate?p=254777111222&a=2000'
+      });
+    });
+  })
+});

--- a/server/src/core/bulk-messaging/tests/recipient-resolver.test.ts
+++ b/server/src/core/bulk-messaging/tests/recipient-resolver.test.ts
@@ -1,0 +1,85 @@
+import { UserService } from '../../user';
+import { DefaultRecipientResolver } from '../recipient-resolver';
+import { RecipientResolver } from '../types';
+
+
+describe('DefaultRecipientResolver', () => {
+  let users: UserService;
+  let resolver: RecipientResolver;
+
+    beforeEach(() => {
+      users = {
+        // @ts-ignore  
+        getAllBeneficiaries: () => Promise.resolve([
+          { _id: 'b1' },
+          { _id: 'b2' }
+        ]),
+        // @ts-ignore
+        getAllDonors: () => Promise.resolve([
+          { _id: 'd1' },
+          { _id: 'd2' }
+        ]),
+        // @ts-ignore
+        getByPhone: (phone) => Promise.resolve(
+          phone === '254700111222' ? { _id: 'u1' } :
+          phone === '254700111333' ? { _id: 'u2' } :
+          { _id: 'u3' }
+        )
+      }
+
+      resolver = new DefaultRecipientResolver({ users });
+    });
+
+  describe('resolve', () => {
+    test('should return all donors if recipient is donors', async () => {
+      const result = await resolver.resolve('donors');
+      expect(result).toEqual([
+        { _id: 'd1' },
+        { _id: 'd2' }
+      ])
+    });
+
+    test('should return all beneficiaries if recipient is beneficiaries', async () => {
+      const result = await resolver.resolve('beneficiaries');
+      expect(result).toEqual([
+        { _id: 'b1' },
+        { _id: 'b2' }
+      ])
+    });
+
+    test('should return user with specified phone number if recipient is a valid phone number', async () => {
+      let result = await resolver.resolve('254700111222');
+      expect(result).toEqual([
+        { _id: 'u1' }
+      ]);
+
+      result = await resolver.resolve('254700111333');
+      expect(result).toEqual([
+        { _id: 'u2' }
+      ]);
+    });
+
+  });
+
+  describe('canResolve', () => {
+    test('should return true for donors', () => {
+      expect(resolver.canResolve('donors')).toBe(true);
+    });
+
+    test('should return true for beneficiaries', () => {
+      expect(resolver.canResolve('beneficiaries')).toBe(true);
+    });
+
+    test('should return true for valid phone numbers', () => {
+      expect(resolver.canResolve('254111222333')).toBe(true);
+    });
+
+    test('should return false for invalid phone numbers', () => {
+      expect(resolver.canResolve('0711222333')).toBe(false);
+    });
+
+    test('should return false for unknown groups', () => {
+      expect(resolver.canResolve('test')).toBe(false);
+    });
+  });
+});

--- a/server/src/core/bulk-messaging/tests/template-resolver.test.ts
+++ b/server/src/core/bulk-messaging/tests/template-resolver.test.ts
@@ -1,0 +1,36 @@
+import { DefaultMessageTemplateResolver } from '../template-resolver';
+import { MessageTemplateContext } from '../types';
+
+describe('DefaultMessageTemplateResolver', () => {
+  describe('resolve', () => {
+    test('should replace placeholders with context variables', async () => {
+      const resolver = new DefaultMessageTemplateResolver();
+      const template = 'Hi {firstName}, we would like to announce a new feature. Please visit {baseUrl}/new-feature for more info. To donate, click {donateLink}';
+      const context: MessageTemplateContext = {
+        firstName: 'John',
+        baseUrl: 'https://test.com',
+        donateLink: 'https://donateLink'
+      };
+
+      const message = await resolver.resolve(context, template);
+      expect(message).toEqual(
+        'Hi John, we would like to announce a new feature. Please visit https://test.com/new-feature for more info. To donate, click https://donateLink'
+      );
+    });
+
+    test('placeholders should be case insensitive', async () => {
+      const resolver = new DefaultMessageTemplateResolver();
+      const template = 'Hi {FIRSTNAME}, we would like to announce a new feature. Please visit {baseurl}/new-feature for more info. To donate, click {Donatelink}';
+      const context: MessageTemplateContext = {
+        firstName: 'John',
+        baseUrl: 'https://test.com',
+        donateLink: 'https://donateLink'
+      };
+
+      const message = await resolver.resolve(context, template);
+      expect(message).toEqual(
+        'Hi John, we would like to announce a new feature. Please visit https://test.com/new-feature for more info. To donate, click https://donateLink'
+      );
+    })
+  });
+});

--- a/server/src/core/bulk-messaging/types.ts
+++ b/server/src/core/bulk-messaging/types.ts
@@ -1,0 +1,37 @@
+import { User } from '../user';
+
+export interface BulkMessageService {
+  send(recipients: string[], messageTemplate: string): Promise<void>;
+}
+
+export interface MessageTemplateContext {
+  firstName: string;
+  donateLink: string;
+  baseUrl: string;
+}
+
+export interface MessageContextFactory {
+  createContextFromUser(user: User): Promise<MessageTemplateContext>;
+}
+
+export interface MessageTemplateResolver {
+  resolve(context: MessageTemplateContext, messageTemplate: string): Promise<string>;
+}
+
+export interface RecipientResolver {
+  canResolve(recipient: string): boolean;
+  resolve(recipient: string): Promise<User[]>;
+}
+
+export interface MessagePlaceholderResolver {
+  canResolve(placeholder: string): boolean;
+  resolve(placeholder: string): Promise<string>;
+}
+
+export interface TemplateValidator {
+  validate(messageTemplate: string): boolean;
+}
+
+export interface MessageSender {
+  sendMessage(recipient: User, message: string): Promise<void>
+}

--- a/server/src/core/bulk-messaging/types.ts
+++ b/server/src/core/bulk-messaging/types.ts
@@ -5,6 +5,7 @@ export interface BulkMessageService {
 }
 
 export interface MessageTemplateContext {
+  [placeholder: string]: string;
   firstName: string;
   donateLink: string;
   baseUrl: string;

--- a/server/src/core/bulk-messaging/types.ts
+++ b/server/src/core/bulk-messaging/types.ts
@@ -1,39 +1,119 @@
 import { User } from '../user';
 
+/**
+ * Sends a bulk message to many users based on a single
+ * message template.
+ */
 export interface BulkMessageService {
+  /**
+   * Sends message to all recipients based on the specified template.
+   * Each recipient receives a personalized version of the message.
+   * @param recipients List of recipient. A recipient may be a valid phone number (2547xxxxxxxx) or a group like 'donors' or 'beneficiaries'
+   * @param messageTemplate A template of the message to send. It may contain placeholders like {firstName}, {donateLink}, or {baseUrl}
+   * @returns a report object with information such as number of recipients and errors that occurred
+   */
   send(recipients: string[], messageTemplate: string): Promise<BulkMessageReport>;
+  /**
+   * Previews what the message would look like after it has been personalized
+   * for a (dummy) user. This should you confirm that the message template
+   * is correct before sending it out.
+   * @param messageTemplate A template of the message to send. It may contain placeholders like {firstName}, {donateLink}, or {baseUrl}
+   */
   previewMessage(messageTemplate: string): Promise<string>;
 }
 
+/**
+ * Creates a message context that's used by the `MessageTemplateResolver` to
+ * personalize message templates
+ */
 export interface MessageContextFactory {
+  /**
+   * Creates a message context with values from the specified user
+   * @param user 
+   */
   createContextFromUser(user: User): Promise<MessageTemplateContext>;
 }
 
+/**
+ * Personalizes messages for a given user by replacing
+ * placeholders in a template with actual values
+ */
 export interface MessageTemplateResolver {
+  /**
+   * Personalize the message template by replacing its placeholders
+   * with values from the given context
+   * @param context 
+   * @param messageTemplate 
+   */
   resolve(context: MessageTemplateContext, messageTemplate: string): Promise<string>;
 }
 
+/**
+ * Finds users that correspond to a given recipient group
+ */
 export interface RecipientResolver {
+  /**
+   * Checks whether this resolver knows how to handle the specified recipient
+   * @param recipient
+   */
   canResolve(recipient: string): boolean;
+  /**
+   * Returns that users that match the specified recipient group
+   * @param recipient 
+   */
   resolve(recipient: string): Promise<User[]>;
 }
 
+/**
+ * Used by the `BulkMessageService` to transport
+ * a message to a user
+ */
 export interface BulkMessagesTransport {
+  /**
+   * Sends the specified message to the specified user
+   * @param recipient 
+   * @param message 
+   */
   sendMessage(recipient: User, message: string): Promise<void>
 }
 
+/**
+ * Contains information about a bulk messaging
+ * process
+ */
 export interface BulkMessageReport {
+  /**
+   * The number of users to whom a message was successfuly sent
+   */
   numRecipients: number;
+  /**
+   * The number of errors that occurred
+   */
   numFailed: number;
+  /**
+   * Information about each error
+   */
   errors: BulkMessageReportError[];
 }
 
 export interface BulkMessageReportError {
+  /**
+   * Error message
+   */
   message: string;
+  /**
+   * The recipientGroup that was being processed when this error occurred
+   */
   recipientGroup?: string;
+  /**
+   * The error that a message was being sent to when this error occurred
+   */
   user?: string;
 }
 
+/**
+ * Contains data used to personalize a message template
+ */
 export interface MessageTemplateContext {
   [placeholder: string]: string;
   firstName: string;

--- a/server/src/core/bulk-messaging/types.ts
+++ b/server/src/core/bulk-messaging/types.ts
@@ -1,14 +1,8 @@
 import { User } from '../user';
 
 export interface BulkMessageService {
-  send(recipients: string[], messageTemplate: string): Promise<void>;
-}
-
-export interface MessageTemplateContext {
-  [placeholder: string]: string;
-  firstName: string;
-  donateLink: string;
-  baseUrl: string;
+  send(recipients: string[], messageTemplate: string): Promise<BulkMessageReport>;
+  previewMessage(messageTemplate: string): Promise<string>;
 }
 
 export interface MessageContextFactory {
@@ -24,15 +18,25 @@ export interface RecipientResolver {
   resolve(recipient: string): Promise<User[]>;
 }
 
-export interface MessagePlaceholderResolver {
-  canResolve(placeholder: string): boolean;
-  resolve(placeholder: string): Promise<string>;
-}
-
-export interface TemplateValidator {
-  validate(messageTemplate: string): boolean;
-}
-
-export interface MessageSender {
+export interface BulkMessagesTransport {
   sendMessage(recipient: User, message: string): Promise<void>
+}
+
+export interface BulkMessageReport {
+  numRecipients: number;
+  numFailed: number;
+  errors: BulkMessageReportError[];
+}
+
+export interface BulkMessageReportError {
+  message: string;
+  recipientGroup?: string;
+  user?: string;
+}
+
+export interface MessageTemplateContext {
+  [placeholder: string]: string;
+  firstName: string;
+  donateLink: string;
+  baseUrl: string;
 }

--- a/server/src/core/bulk-messaging/types.ts
+++ b/server/src/core/bulk-messaging/types.ts
@@ -83,9 +83,13 @@ export interface BulkMessagesTransport {
  */
 export interface BulkMessageReport {
   /**
-   * The number of users to whom a message was successfuly sent
+   * The number of users to whom a message was successfully sent
    */
   numRecipients: number;
+  /**
+   * The ids of recipients to whom messages were sent successfully
+   */
+  recipients: BulkMessageReportRecipient[];
   /**
    * The number of errors that occurred
    */
@@ -94,6 +98,11 @@ export interface BulkMessageReport {
    * Information about each error
    */
   errors: BulkMessageReportError[];
+}
+
+export interface BulkMessageReportRecipient {
+  name: string;
+  user: string;
 }
 
 export interface BulkMessageReportError {
@@ -106,9 +115,13 @@ export interface BulkMessageReportError {
    */
   recipientGroup?: string;
   /**
-   * The error that a message was being sent to when this error occurred
+   * The user that a message was being sent to when this error occurred
    */
   user?: string;
+  /**
+   * The name of the user that a message was being sent to when this error occurred
+   */
+  name?: string;
 }
 
 /**

--- a/server/src/core/error.ts
+++ b/server/src/core/error.ts
@@ -42,8 +42,10 @@ export function isMongoDuplicateKeyError(error: MongoError, key?: any): boolean 
 
 // Our error codes
 export type ErrorCode = 
+  // generic app error
+  'appError'
   // database error occurred when performing db operation
-  'dbOpFailed'
+  | 'dbOpFailed'
   // database error occurred when connecting to db
   | 'dbConnectionFailed'
   | 'loginFailed'
@@ -75,7 +77,7 @@ export type ErrorCode =
   | 'transactionRejected'
   | 'insufficientFunds';
 
-export function createAppError(message: string, code: ErrorCode): AppError {
+export function createAppError(message: string, code: ErrorCode = 'appError'): AppError {
   return new AppError(message, code);
 }
 

--- a/server/src/core/user/index.ts
+++ b/server/src/core/user/index.ts
@@ -1,2 +1,2 @@
-export { User, UserCreateArgs, UserService, UserRole, UserInvitationEventData } from './types';
+export { User, UserCreateArgs, UserService, UserRole, UserInvitationEventData, UserAddVettedBeneficiaryArgs } from './types';
 export { Users, COLLECTION  } from './user-service';

--- a/server/src/core/user/types.ts
+++ b/server/src/core/user/types.ts
@@ -298,6 +298,10 @@ export interface UserService {
    * Returns all users with the role donor
    */
   getAllDonors(): Promise<User[]>
+  /**
+   * Returns all beneficiaries
+   */
+  getAllBeneficiaries(): Promise<User[]>
 };
 
 export interface UserCreateAnonymousArgs {

--- a/server/src/core/user/user-service.ts
+++ b/server/src/core/user/user-service.ts
@@ -868,4 +868,14 @@ export class Users implements UserService {
       throw createDbOpFailedError(e.message);
     }
   }
+
+  async getAllBeneficiaries(): Promise<User[]> {
+    try {
+      const donors = await this.collection.find({ roles: { $in: ['beneficiary'] } }, { projection: SAFE_USER_PROJECTION }).toArray();
+      return donors;
+    }
+    catch (e) {
+      throw createDbOpFailedError(e.message);
+    }
+  }
 }

--- a/server/src/core/util/validation-util.ts
+++ b/server/src/core/util/validation-util.ts
@@ -65,3 +65,18 @@ export const isAnonymousSchema = joi.boolean()
   })
 
 export const validateEmail = makeValidatorFromJoiSchema(emailValidationSchema);
+
+/**
+ * checks whether the specified input is valid
+ * @param input 
+ * @param validator 
+ */
+export function isValid(input: any, validator: Function): boolean {
+  try {
+    validator(input);
+    return true;
+  }
+  catch (e) {
+    return false;
+  }
+}

--- a/server/src/core/util/validation-util.ts
+++ b/server/src/core/util/validation-util.ts
@@ -1,6 +1,5 @@
 import * as joi from '@hapi/joi';
 import { createValidationError } from '../error';
-import { messages } from '..';
 
 export function makeValidatorFromJoiSchema<TArgs = any>(schema: joi.Schema) {
   return (args: TArgs) => {
@@ -30,6 +29,8 @@ export const phoneValidationSchema = joi.string()
     'string.empty': 'Please enter your phone number',
     'string.pattern.base': 'Invalid phone number. Must start with 254 and be 12 digit long'
   });
+
+export const validatePhone = makeValidatorFromJoiSchema(phoneValidationSchema);
 
 export const passwordValidationSchema = joi.string()
   .required()


### PR DESCRIPTION
## Related Issues

*List of issues fixed by this pull request*

Fixes #189 

## Description

This feature allows an admin to send a bulk message to users via the Admin CLI. Currently the feature only supports SMS but it's very easy to add email support. Here's an overview of what's supported:

- [x] New command added to the admin CLI to send bulk messages
- [x] You can specify multiple recipients using phone numbers, or using built-in groups like `donors` and `beneficiaries`
- [x] Supports placeholders in message. Currently supported placeholders are `{firstName}`, `{donateLink}` and `{baseUrl}`
- [x] Displays a preview of the message before sending it out to users
- [x] Validates recipients before sending message, so typos and invalid numbers are caught ahead of time
- [x] Reports number of recipients and number of errors that occurred after sending. For each error that occurs, an error message and the associated recipient are displayed to allow the admin to manually re-send if necessary
- [x] Modular implementation that makes it easy to expand support for new transports (e.g. sending via email) and new placeholders in the future
- [x] Unit tests

I also added a command to display user information based on id or phone number.

![Screenshot 2020-12-12 at 17 02 57](https://user-images.githubusercontent.com/8460169/101986421-c4d93280-3c9e-11eb-8544-c42273f82d97.png)
![Screenshot 2020-12-12 at 17 46 11](https://user-images.githubusercontent.com/8460169/101986910-fd2e4000-3ca1-11eb-99d4-2c356f25516b.png)

